### PR TITLE
Handler: `client`, `getAllClients`, `getAllRooms` and `withRooms().getClients()`

### DIFF
--- a/example/actions/chat.ts
+++ b/example/actions/chat.ts
@@ -3,9 +3,9 @@ import { actionsFactory } from "../factories";
 
 export const onChat = actionsFactory.build({
   input: z.tuple([z.string()]),
-  handler: async ({ input: [message], socketId, broadcast, logger }) => {
+  handler: async ({ input: [message], client, broadcast, logger }) => {
     try {
-      broadcast("chat", message, { from: socketId });
+      broadcast("chat", message, { from: client.id });
     } catch (error) {
       logger.error("Failed to broadcast", error);
     }

--- a/example/actions/subscribe.ts
+++ b/example/actions/subscribe.ts
@@ -4,7 +4,7 @@ import { actionsFactory } from "../factories";
 /** @desc The action demonstrates no acknowledgement and constraints on emission awareness */
 export const onSubscribe = actionsFactory.build({
   input: z.tuple([]).rest(z.unknown()),
-  handler: async ({ logger, emit, isConnected }) => {
+  handler: async ({ logger, emit, client }) => {
     logger.info("Subscribed");
     while (true) {
       try {
@@ -12,7 +12,7 @@ export const onSubscribe = actionsFactory.build({
         await new Promise<void>((resolve, reject) => {
           const timer = setTimeout(() => {
             clearTimeout(timer);
-            if (!isConnected()) {
+            if (!client.isConnected()) {
               reject("Disconnected");
             }
             resolve();

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -42,20 +42,24 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getRooms: getRoomsMock,
-        isConnected: isConnectedMock,
-        socketId: "ID",
+        client: {
+          getRooms: getRoomsMock,
+          isConnected: isConnectedMock,
+          id: "ID",
+        },
       });
       expect(loggerMock.error).not.toHaveBeenCalled();
       expect(simpleHandler).toHaveBeenLastCalledWith({
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getRooms: getRoomsMock,
         emit: emitMock,
         input: ["some"],
-        isConnected: isConnectedMock,
         logger: loggerMock,
-        socketId: "ID",
+        client: {
+          isConnected: isConnectedMock,
+          getRooms: getRoomsMock,
+          id: "ID",
+        },
       });
     });
 
@@ -68,20 +72,24 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getRooms: getRoomsMock,
-        isConnected: isConnectedMock,
-        socketId: "ID",
+        client: {
+          getRooms: getRoomsMock,
+          isConnected: isConnectedMock,
+          id: "ID",
+        },
       });
       expect(loggerMock.error).not.toHaveBeenCalled();
       expect(ackHandler).toHaveBeenLastCalledWith({
+        client: {
+          id: "ID",
+          getRooms: getRoomsMock,
+          isConnected: isConnectedMock,
+        },
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getRooms: getRoomsMock,
         emit: emitMock,
         input: ["some"],
-        isConnected: isConnectedMock,
         logger: loggerMock,
-        socketId: "ID",
       });
       expect(ackMock).toHaveBeenLastCalledWith(123); // from ackHandler
     });
@@ -94,9 +102,11 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getRooms: getRoomsMock,
-        isConnected: isConnectedMock,
-        socketId: "ID",
+        client: {
+          getRooms: getRoomsMock,
+          isConnected: isConnectedMock,
+          id: "ID",
+        },
       });
       expect(loggerMock.error).toHaveBeenCalled();
     });

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -33,6 +33,8 @@ describe("Action", () => {
     const isConnectedMock = vi.fn();
     const withRoomsMock = vi.fn();
     const getRoomsMock = vi.fn();
+    const getAllRoomsMock = vi.fn();
+    const getAllClientsMock = vi.fn();
 
     test("should handle simple action", async () => {
       await simpleAction.execute({
@@ -42,6 +44,8 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
+        getAllClients: getAllClientsMock,
+        getAllRooms: getAllRoomsMock,
         client: {
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
@@ -52,6 +56,8 @@ describe("Action", () => {
       expect(simpleHandler).toHaveBeenLastCalledWith({
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
+        getAllClients: getAllClientsMock,
+        getAllRooms: getAllRoomsMock,
         emit: emitMock,
         input: ["some"],
         logger: loggerMock,
@@ -72,6 +78,8 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
+        getAllClients: getAllClientsMock,
+        getAllRooms: getAllRoomsMock,
         client: {
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
@@ -87,6 +95,8 @@ describe("Action", () => {
         },
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
+        getAllClients: getAllClientsMock,
+        getAllRooms: getAllRoomsMock,
         emit: emitMock,
         input: ["some"],
         logger: loggerMock,
@@ -102,6 +112,8 @@ describe("Action", () => {
         emit: emitMock,
         broadcast: broadcastMock,
         withRooms: withRoomsMock,
+        getAllClients: getAllClientsMock,
+        getAllRooms: getAllRoomsMock,
         client: {
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,6 +17,8 @@ export interface HandlingFeatures<E extends EmissionMap> {
   emit: Emitter<E>;
   broadcast: Broadcaster<E>;
   withRooms: RoomService<E>;
+  getAllRooms: () => string[];
+  getAllClients: () => Promise<{ id: string; rooms: string[] }[]>;
 }
 
 export type Handler<IN, OUT, E extends EmissionMap> = (

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,13 +5,14 @@ import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
 import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 
-export interface SocketFeatures {
+export interface Client {
   isConnected: () => boolean;
-  socketId: Socket["id"];
+  id: Socket["id"];
   getRooms: () => string[];
 }
 
 export interface HandlingFeatures<E extends EmissionMap> {
+  client: Client;
   logger: AbstractLogger;
   emit: Emitter<E>;
   broadcast: Broadcaster<E>;
@@ -21,8 +22,7 @@ export interface HandlingFeatures<E extends EmissionMap> {
 export type Handler<IN, OUT, E extends EmissionMap> = (
   params: {
     input: IN;
-  } & SocketFeatures &
-    HandlingFeatures<E>,
+  } & HandlingFeatures<E>,
 ) => Promise<OUT>;
 
 export abstract class AbstractAction {
@@ -30,8 +30,7 @@ export abstract class AbstractAction {
     params: {
       event: string;
       params: unknown[];
-    } & SocketFeatures &
-      HandlingFeatures<EmissionMap>,
+    } & HandlingFeatures<EmissionMap>,
   ): Promise<void>;
 }
 
@@ -88,8 +87,7 @@ export class Action<
   }: {
     event: string;
     params: unknown[];
-  } & SocketFeatures &
-    HandlingFeatures<EmissionMap>): Promise<void> {
+  } & HandlingFeatures<EmissionMap>): Promise<void> {
     try {
       const input = this.#parseInput(params);
       logger.debug(

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
 import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
+import { RemoteClint } from "./utils";
 
 export interface Client {
   isConnected: () => boolean;
@@ -18,7 +19,7 @@ export interface HandlingFeatures<E extends EmissionMap> {
   broadcast: Broadcaster<E>;
   withRooms: RoomService<E>;
   getAllRooms: () => string[];
-  getAllClients: () => Promise<{ id: string; rooms: string[] }[]>;
+  getAllClients: () => Promise<RemoteClint[]>;
 }
 
 export type Handler<IN, OUT, E extends EmissionMap> = (

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -68,24 +68,25 @@ describe("Attach", () => {
       expect(actionsMock.test.execute).toHaveBeenLastCalledWith({
         broadcast: expect.any(Function),
         withRooms: expect.any(Function),
-        getRooms: expect.any(Function),
         emit: expect.any(Function),
         event: "test",
-        isConnected: expect.any(Function),
         logger: loggerMock,
         params: [[123, 456]],
-        socketId: "ID",
+        client: {
+          id: "ID",
+          isConnected: expect.any(Function),
+          getRooms: expect.any(Function),
+        },
       });
 
       // getRooms:
-      expect(actionsMock.test.execute.mock.lastCall[0].getRooms()).toEqual([
-        "room1",
-        "room2",
-      ]);
+      expect(
+        actionsMock.test.execute.mock.lastCall[0].client.getRooms(),
+      ).toEqual(["room1", "room2"]);
 
       // isConnected:
       expect(
-        actionsMock.test.execute.mock.lastCall[0].isConnected(),
+        actionsMock.test.execute.mock.lastCall[0].client.isConnected(),
       ).toBeFalsy();
     });
   });

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -26,7 +26,7 @@ describe("Attach", () => {
       of: vi.fn(() => ({
         adapter: adapterMock,
       })),
-      fetchSockets: vi.fn(() => [
+      fetchSockets: vi.fn(async () => [
         { id: "ID", rooms: new Set(["room1", "room2"]) },
         { id: "other", rooms: new Set(["room3"]) },
       ]),

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -13,9 +13,23 @@ describe("Attach", () => {
       on: vi.fn(),
       onAny: vi.fn(),
     };
+    const adapterMock = {
+      rooms: new Map([
+        ["room1", ["ID"]],
+        ["room2", ["ID"]],
+        ["room3", ["other"]],
+      ]),
+    };
     const ioMock = {
       on: vi.fn(),
       attach: vi.fn(),
+      of: vi.fn(() => ({
+        adapter: adapterMock,
+      })),
+      fetchSockets: vi.fn(() => [
+        { id: "ID", rooms: new Set(["room1", "room2"]) },
+        { id: "other", rooms: new Set(["room3"]) },
+      ]),
     };
     const targetMock = {
       address: vi.fn(),
@@ -68,6 +82,8 @@ describe("Attach", () => {
       expect(actionsMock.test.execute).toHaveBeenLastCalledWith({
         broadcast: expect.any(Function),
         withRooms: expect.any(Function),
+        getAllClients: expect.any(Function),
+        getAllRooms: expect.any(Function),
         emit: expect.any(Function),
         event: "test",
         logger: loggerMock,
@@ -88,6 +104,22 @@ describe("Attach", () => {
       expect(
         actionsMock.test.execute.mock.lastCall[0].client.isConnected(),
       ).toBeFalsy();
+
+      // getAllRooms:
+      expect(actionsMock.test.execute.mock.lastCall[0].getAllRooms()).toEqual([
+        "room1",
+        "room2",
+        "room3",
+      ]);
+      expect(ioMock.of).toHaveBeenLastCalledWith("/");
+
+      // getAllClients:
+      await expect(
+        actionsMock.test.execute.mock.lastCall[0].getAllClients(),
+      ).resolves.toEqual([
+        { id: "ID", rooms: ["room1", "room2"] },
+        { id: "other", rooms: ["room3"] },
+      ]);
     });
   });
 });

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -44,6 +44,12 @@ export const attachSockets = <E extends EmissionMap>({
   onAnyEvent?: Handler<[string], void, E>;
 }): Server => {
   config.logger.info("ZOD-SOCKETS", target.address());
+  const getAllRooms = () => Array.from(io.of("/").adapter.rooms.keys());
+  const getAllClients = async () =>
+    (await io.fetchSockets()).map(({ id, rooms }) => ({
+      id,
+      rooms: Array.from(rooms),
+    }));
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });
@@ -58,6 +64,8 @@ export const attachSockets = <E extends EmissionMap>({
       emit,
       broadcast,
       withRooms,
+      getAllClients,
+      getAllRooms,
     };
     await onConnection({ input: [], ...commons });
     socket.onAny((event) => onAnyEvent({ input: [event], ...commons }));

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -8,6 +8,7 @@ import {
   makeEmitter,
   makeRoomService,
 } from "./emission";
+import { mapFetchedSockets } from "./utils";
 
 export const attachSockets = <E extends EmissionMap>({
   io,
@@ -45,11 +46,7 @@ export const attachSockets = <E extends EmissionMap>({
 }): Server => {
   config.logger.info("ZOD-SOCKETS", target.address());
   const getAllRooms = () => Array.from(io.of("/").adapter.rooms.keys());
-  const getAllClients = async () =>
-    (await io.fetchSockets()).map(({ id, rooms }) => ({
-      id,
-      rooms: Array.from(rooms),
-    }));
+  const getAllClients = async () => mapFetchedSockets(await io.fetchSockets());
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import type { Server } from "socket.io";
-import { ActionMap, Handler, HandlingFeatures, SocketFeatures } from "./action";
+import { ActionMap, Handler, HandlingFeatures } from "./action";
 import { Config } from "./config";
 import {
   EmissionMap,
@@ -14,12 +14,12 @@ export const attachSockets = <E extends EmissionMap>({
   actions,
   target,
   config,
-  onConnection = ({ socketId }) =>
-    config.logger.debug("User connected", socketId),
-  onDisconnect = ({ socketId }) =>
-    config.logger.debug("User disconnected", socketId),
-  onAnyEvent = ({ input: [event], socketId }) =>
-    config.logger.debug(`${event} from ${socketId}`),
+  onConnection = ({ client }) =>
+    config.logger.debug("User connected", client.id),
+  onDisconnect = ({ client }) =>
+    config.logger.debug("User disconnected", client.id),
+  onAnyEvent = ({ input: [event], client }) =>
+    config.logger.debug(`${event} from ${client.id}`),
 }: {
   /**
    * @desc The Socket.IO server
@@ -48,10 +48,12 @@ export const attachSockets = <E extends EmissionMap>({
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });
     const withRooms = makeRoomService({ socket, config });
-    const commons: SocketFeatures & HandlingFeatures<E> = {
-      socketId: socket.id,
-      isConnected: () => socket.connected,
-      getRooms: () => Array.from(socket.rooms),
+    const commons: HandlingFeatures<E> = {
+      client: {
+        id: socket.id,
+        isConnected: () => socket.connected,
+        getRooms: () => Array.from(socket.rooms),
+      },
       logger: config.logger,
       emit,
       broadcast,

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -27,6 +27,7 @@ export type Broadcaster<E extends EmissionMap> = <K extends keyof E>(
   ...args: z.input<E[K]["schema"]>
 ) => Promise<z.output<TuplesOrTrue<E[K]["ack"]>>>;
 
+// @todo add clients there
 export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   broadcast: Broadcaster<E>;
   join: () => void | Promise<void>;

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import type { Socket } from "socket.io";
 import { z } from "zod";
 import { Config } from "./config";
+import { RemoteClint, mapFetchedSockets } from "./utils";
 
 export interface Emission {
   schema: z.AnyZodTuple;
@@ -27,11 +28,11 @@ export type Broadcaster<E extends EmissionMap> = <K extends keyof E>(
   ...args: z.input<E[K]["schema"]>
 ) => Promise<z.output<TuplesOrTrue<E[K]["ack"]>>>;
 
-// @todo add clients there
 export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   broadcast: Broadcaster<E>;
   join: () => void | Promise<void>;
   leave: () => void | Promise<void>;
+  getClients: () => Promise<RemoteClint[]>;
 };
 
 /**
@@ -85,6 +86,8 @@ export const makeRoomService =
     ...rest
   }: MakerParams<E>): RoomService<E> =>
   (rooms) => ({
+    getClients: async () =>
+      mapFetchedSockets(await socket.in(rooms).fetchSockets()),
     join: () => socket.join(rooms),
     leave: () =>
       typeof rooms === "string"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { attachSockets } from "./attach";
 export { createConfig, type Config } from "./config";
 export { ActionsFactory } from "./actions-factory";
-export type { ActionMap, SocketFeatures, HandlingFeatures } from "./action";
+export type { ActionMap, HandlingFeatures } from "./action";
 
 // issue 952
 export type { EmissionMap } from "./emission";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+import { RemoteSocket } from "socket.io";
+
+export interface RemoteClint {
+  id: string;
+  rooms: string[];
+}
+
+export const mapFetchedSockets = (
+  sockets: RemoteSocket<{}, unknown>[],
+): RemoteClint[] =>
+  sockets.map(({ id, rooms }) => ({ id, rooms: Array.from(rooms) }));


### PR DESCRIPTION
- moving the current socket features to `client` argument,
  - renaming `socketId` to `client.id`,
- adding `getClients()` to `withRooms()`,
- adding `getAllClients()` and `getAllRooms()`