### PR TITLE
`client` and `all` scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Version 0
 
+### v0.3.0
+
+- New argument for the Action handler: `all` having methods:
+  - `broadcast()` (moved);
+  - `getRooms()` — returns all the available rooms;
+  - `getClients()` — returns all the familiar clients.
+- The argument `emit()` of the Action handler moved into `client` one.
+- The argument `withRooms()` of the Action handler now also provides the `getClients()` method (clients in the rooms).
+
 ### v0.2.3
 
 - Adding `getRooms()` and `withRooms()` providing `join()`, `leave()` and `broadcast()` methods to the Action handler.

--- a/example/actions/chat.ts
+++ b/example/actions/chat.ts
@@ -3,9 +3,9 @@ import { actionsFactory } from "../factories";
 
 export const onChat = actionsFactory.build({
   input: z.tuple([z.string()]),
-  handler: async ({ input: [message], client, broadcast, logger }) => {
+  handler: async ({ input: [message], client, all, logger }) => {
     try {
-      broadcast("chat", message, { from: client.id });
+      await all.broadcast("chat", message, { from: client.id });
     } catch (error) {
       logger.error("Failed to broadcast", error);
     }

--- a/example/actions/subscribe.ts
+++ b/example/actions/subscribe.ts
@@ -4,11 +4,11 @@ import { actionsFactory } from "../factories";
 /** @desc The action demonstrates no acknowledgement and constraints on emission awareness */
 export const onSubscribe = actionsFactory.build({
   input: z.tuple([]).rest(z.unknown()),
-  handler: async ({ logger, emit, client }) => {
+  handler: async ({ logger, client }) => {
     logger.info("Subscribed");
     while (true) {
       try {
-        emit("time", new Date()); // <— payload type constraints
+        await client.emit("time", new Date()); // <— payload type constraints
         await new Promise<void>((resolve, reject) => {
           const timer = setTimeout(() => {
             clearTimeout(timer);

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -41,12 +41,14 @@ describe("Action", () => {
         event: "test",
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some"],
-        emit: emitMock,
-        broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          broadcast: broadcastMock,
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+        },
         client: {
+          emit: emitMock,
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
           id: "ID",
@@ -54,14 +56,16 @@ describe("Action", () => {
       });
       expect(loggerMock.error).not.toHaveBeenCalled();
       expect(simpleHandler).toHaveBeenLastCalledWith({
-        broadcast: broadcastMock,
-        withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
-        emit: emitMock,
         input: ["some"],
         logger: loggerMock,
+        withRooms: withRoomsMock,
+        all: {
+          broadcast: broadcastMock,
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+        },
         client: {
+          emit: emitMock,
           isConnected: isConnectedMock,
           getRooms: getRoomsMock,
           id: "ID",
@@ -75,12 +79,14 @@ describe("Action", () => {
         event: "test",
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some", ackMock],
-        emit: emitMock,
-        broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          broadcast: broadcastMock,
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+        },
         client: {
+          emit: emitMock,
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
           id: "ID",
@@ -92,12 +98,14 @@ describe("Action", () => {
           id: "ID",
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
+          emit: emitMock,
         },
-        broadcast: broadcastMock,
+        all: {
+          broadcast: broadcastMock,
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+        },
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
-        emit: emitMock,
         input: ["some"],
         logger: loggerMock,
       });
@@ -109,15 +117,17 @@ describe("Action", () => {
         event: "test",
         logger: loggerMock as unknown as AbstractLogger,
         params: [], // too short
-        emit: emitMock,
-        broadcast: broadcastMock,
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          broadcast: broadcastMock,
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+        },
         client: {
+          id: "ID",
           getRooms: getRoomsMock,
           isConnected: isConnectedMock,
-          id: "ID",
+          emit: emitMock,
         },
       });
       expect(loggerMock.error).toHaveBeenCalled();

--- a/src/action.ts
+++ b/src/action.ts
@@ -13,15 +13,15 @@ export interface Client<E extends EmissionMap> {
   id: Socket["id"];
   /** @desc Returns the list of the rooms the client in */
   getRooms: () => string[];
-  /** @desc Sends an event to the client */
+  /** @desc Sends a new event to the client (this is not acknowledgement) */
   emit: Emitter<E>;
 }
 
 export interface HandlingFeatures<E extends EmissionMap> {
   logger: AbstractLogger;
-  /** @desc The owner of the received event */
+  /** @desc The scope of the owner of the received event */
   client: Client<E>;
-  /** @desc Provides global scope methods */
+  /** @desc The global scope */
   all: {
     /** @desc Emits to everyone */
     broadcast: Broadcaster<E>;

--- a/src/action.ts
+++ b/src/action.ts
@@ -6,32 +6,32 @@ import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 import { RemoteClint } from "./utils";
 
-export interface Client {
+export interface Client<E extends EmissionMap> {
   /** @alias Socket.connected */
   isConnected: () => boolean;
   /** @alias Socket.id */
   id: Socket["id"];
   /** @desc Returns the list of the rooms the client in */
   getRooms: () => string[];
+  /** @desc Sends an event to the client */
+  emit: Emitter<E>;
 }
 
 export interface HandlingFeatures<E extends EmissionMap> {
-  /** @desc The owner of the received event */
-  client: Client;
   logger: AbstractLogger;
-  /**
-   * @desc Emits towards the owner of the received event
-   * @todo consider moving to "client"
-   * */
-  emit: Emitter<E>;
-  /** @desc Emits to everyone */
-  broadcast: Broadcaster<E>;
+  /** @desc The owner of the received event */
+  client: Client<E>;
+  /** @desc Provides global scope methods */
+  all: {
+    /** @desc Emits to everyone */
+    broadcast: Broadcaster<E>;
+    /** @desc Returns the list of available rooms */
+    getRooms: () => string[];
+    /** @desc Returns the list of familiar clients */
+    getClients: () => Promise<RemoteClint[]>;
+  };
   /** @desc Provides room(s)-scope methods */
   withRooms: RoomService<E>;
-  /** @desc Returns the list of available rooms */
-  getAllRooms: () => string[];
-  /** @desc Returns the list of familiar client */
-  getAllClients: () => Promise<RemoteClint[]>;
 }
 
 export type Handler<IN, OUT, E extends EmissionMap> = (

--- a/src/actions-factory.ts
+++ b/src/actions-factory.ts
@@ -7,7 +7,9 @@ export interface ActionNoAckDef<
   IN extends z.AnyZodTuple,
   E extends EmissionMap,
 > {
+  /** @desc The incoming event payload validation schema (no acknowledgement) */
   input: IN;
+  /** @desc No output schema => no returns => no acknowledgement */
   handler: Handler<z.output<IN>, void, E>;
 }
 
@@ -16,8 +18,11 @@ export interface ActionWithAckDef<
   OUT extends z.AnyZodTuple,
   E extends EmissionMap,
 > {
+  /** @desc The incoming event payload (excl. acknowledgement) validation schema */
   input: IN;
+  /** @desc The acknowledgement validation schema */
   output: OUT;
+  /** @desc The returns become an Acknowledgement */
   handler: Handler<z.output<IN>, z.input<OUT>, E>;
 }
 

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -80,11 +80,7 @@ describe("Attach", () => {
       expect(call).toBeTruthy();
       await call[1]([123, 456]);
       expect(actionsMock.test.execute).toHaveBeenLastCalledWith({
-        broadcast: expect.any(Function),
         withRooms: expect.any(Function),
-        getAllClients: expect.any(Function),
-        getAllRooms: expect.any(Function),
-        emit: expect.any(Function),
         event: "test",
         logger: loggerMock,
         params: [[123, 456]],
@@ -92,30 +88,36 @@ describe("Attach", () => {
           id: "ID",
           isConnected: expect.any(Function),
           getRooms: expect.any(Function),
+          emit: expect.any(Function),
+        },
+        all: {
+          broadcast: expect.any(Function),
+          getClients: expect.any(Function),
+          getRooms: expect.any(Function),
         },
       });
 
-      // getRooms:
+      // client.getRooms:
       expect(
         actionsMock.test.execute.mock.lastCall[0].client.getRooms(),
       ).toEqual(["room1", "room2"]);
 
-      // isConnected:
+      // client.isConnected:
       expect(
         actionsMock.test.execute.mock.lastCall[0].client.isConnected(),
       ).toBeFalsy();
 
-      // getAllRooms:
-      expect(actionsMock.test.execute.mock.lastCall[0].getAllRooms()).toEqual([
+      // all.getRooms:
+      expect(actionsMock.test.execute.mock.lastCall[0].all.getRooms()).toEqual([
         "room1",
         "room2",
         "room3",
       ]);
       expect(ioMock.of).toHaveBeenLastCalledWith("/");
 
-      // getAllClients:
+      // all.getClients:
       await expect(
-        actionsMock.test.execute.mock.lastCall[0].getAllClients(),
+        actionsMock.test.execute.mock.lastCall[0].all.getClients(),
       ).resolves.toEqual([
         { id: "ID", rooms: ["room1", "room2"] },
         { id: "other", rooms: ["room3"] },

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -53,16 +53,18 @@ export const attachSockets = <E extends EmissionMap>({
     const withRooms = makeRoomService({ socket, config });
     const commons: HandlingFeatures<E> = {
       client: {
+        emit,
         id: socket.id,
         isConnected: () => socket.connected,
         getRooms: () => Array.from(socket.rooms),
       },
+      all: {
+        broadcast,
+        getClients: getAllClients,
+        getRooms: getAllRooms,
+      },
       logger: config.logger,
-      emit,
-      broadcast,
       withRooms,
-      getAllClients,
-      getAllRooms,
     };
     await onConnection({ input: [], ...commons });
     socket.onAny((event) => onAnyEvent({ input: [event], ...commons }));


### PR DESCRIPTION
- Moving `emit()` into `client`,
- Moving `getAllClients`, `getAllRooms` and `broadast` into `all` with renaming first two to `getClients` and `getRooms`