### PR TITLE
Ref: using root namespace for `getAllClients`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0
 
+### v0.3.1
+
+- Using `io.of("/")` for both `all.getRooms()` and `all.getClients()`.
+
 ### v0.3.0
 
 - New argument for the Action handler: `all` having methods:

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
 import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
-import { RemoteClint } from "./utils";
+import { RemoteClint } from "./remote-client";
 
 export interface Client<E extends EmissionMap> {
   /** @alias Socket.connected */

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
 import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
-import { RemoteClint } from "./remote-client";
+import { RemoteClient } from "./remote-client";
 
 export interface Client<E extends EmissionMap> {
   /** @alias Socket.connected */
@@ -28,7 +28,7 @@ export interface HandlingFeatures<E extends EmissionMap> {
     /** @desc Returns the list of available rooms */
     getRooms: () => string[];
     /** @desc Returns the list of familiar clients */
-    getClients: () => Promise<RemoteClint[]>;
+    getClients: () => Promise<RemoteClient[]>;
   };
   /** @desc Provides room(s)-scope methods */
   withRooms: RoomService<E>;

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -25,11 +25,11 @@ describe("Attach", () => {
       attach: vi.fn(),
       of: vi.fn(() => ({
         adapter: adapterMock,
+        fetchSockets: vi.fn(async () => [
+          { id: "ID", rooms: new Set(["room1", "room2"]) },
+          { id: "other", rooms: new Set(["room3"]) },
+        ]),
       })),
-      fetchSockets: vi.fn(async () => [
-        { id: "ID", rooms: new Set(["room1", "room2"]) },
-        { id: "other", rooms: new Set(["room3"]) },
-      ]),
     };
     const targetMock = {
       address: vi.fn(),
@@ -56,7 +56,10 @@ describe("Attach", () => {
 
       // on connection:
       await ioMock.on.mock.lastCall![1](socketMock);
-      expect(loggerMock.debug).toHaveBeenLastCalledWith("User connected", "ID");
+      expect(loggerMock.debug).toHaveBeenLastCalledWith(
+        "Client connected",
+        "ID",
+      );
       expect(socketMock.onAny).toHaveBeenLastCalledWith(expect.any(Function));
       expect(socketMock.on).toHaveBeenCalledWith("test", expect.any(Function));
       expect(socketMock.on).toHaveBeenLastCalledWith(
@@ -67,7 +70,7 @@ describe("Attach", () => {
       // on disconnect:
       socketMock.on.mock.lastCall![1]();
       expect(loggerMock.debug).toHaveBeenLastCalledWith(
-        "User disconnected",
+        "Client disconnected",
         "ID",
       );
 

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -16,9 +16,9 @@ export const attachSockets = <E extends EmissionMap>({
   target,
   config,
   onConnection = ({ client }) =>
-    config.logger.debug("User connected", client.id),
+    config.logger.debug("Client connected", client.id),
   onDisconnect = ({ client }) =>
-    config.logger.debug("User disconnected", client.id),
+    config.logger.debug("Client disconnected", client.id),
   onAnyEvent = ({ input: [event], client }) =>
     config.logger.debug(`${event} from ${client.id}`),
 }: {
@@ -46,7 +46,8 @@ export const attachSockets = <E extends EmissionMap>({
 }): Server => {
   config.logger.info("ZOD-SOCKETS", target.address());
   const getAllRooms = () => Array.from(io.of("/").adapter.rooms.keys());
-  const getAllClients = async () => mapFetchedSockets(await io.fetchSockets());
+  const getAllClients = async () =>
+    mapFetchedSockets(await io.of("/").fetchSockets());
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -8,7 +8,7 @@ import {
   makeEmitter,
   makeRoomService,
 } from "./emission";
-import { mapFetchedSockets } from "./utils";
+import { getRemoteClients } from "./remote-client";
 
 export const attachSockets = <E extends EmissionMap>({
   io,
@@ -48,7 +48,7 @@ export const attachSockets = <E extends EmissionMap>({
   const rootNS = io.of("/");
   const getAllRooms = () => Array.from(rootNS.adapter.rooms.keys());
   const getAllClients = async () =>
-    mapFetchedSockets(await rootNS.fetchSockets());
+    getRemoteClients(await rootNS.fetchSockets());
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -45,9 +45,10 @@ export const attachSockets = <E extends EmissionMap>({
   onAnyEvent?: Handler<[string], void, E>;
 }): Server => {
   config.logger.info("ZOD-SOCKETS", target.address());
-  const getAllRooms = () => Array.from(io.of("/").adapter.rooms.keys());
+  const rootNS = io.of("/");
+  const getAllRooms = () => Array.from(rootNS.adapter.rooms.keys());
   const getAllClients = async () =>
-    mapFetchedSockets(await io.of("/").fetchSockets());
+    mapFetchedSockets(await rootNS.fetchSockets());
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ socket, config });
     const broadcast = makeBroadcaster({ socket, config });

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { Socket } from "socket.io";
 import { z } from "zod";
 import { Config } from "./config";
-import { RemoteClint, mapFetchedSockets } from "./utils";
+import { RemoteClint, getRemoteClients } from "./remote-client";
 
 export interface Emission {
   schema: z.AnyZodTuple;
@@ -87,7 +87,7 @@ export const makeRoomService =
   }: MakerParams<E>): RoomService<E> =>
   (rooms) => ({
     getClients: async () =>
-      mapFetchedSockets(await socket.in(rooms).fetchSockets()),
+      getRemoteClients(await socket.in(rooms).fetchSockets()),
     join: () => socket.join(rooms),
     leave: () =>
       typeof rooms === "string"

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { Socket } from "socket.io";
 import { z } from "zod";
 import { Config } from "./config";
-import { RemoteClint, getRemoteClients } from "./remote-client";
+import { RemoteClient, getRemoteClients } from "./remote-client";
 
 export interface Emission {
   schema: z.AnyZodTuple;
@@ -32,7 +32,7 @@ export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   broadcast: Broadcaster<E>;
   join: () => void | Promise<void>;
   leave: () => void | Promise<void>;
-  getClients: () => Promise<RemoteClint[]>;
+  getClients: () => Promise<RemoteClient[]>;
 };
 
 /**

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,11 +1,11 @@
 import { RemoteSocket } from "socket.io";
 
-export interface RemoteClint {
+export interface RemoteClient {
   id: string;
   rooms: string[];
 }
 
 export const getRemoteClients = (
   sockets: RemoteSocket<{}, unknown>[],
-): RemoteClint[] =>
+): RemoteClient[] =>
   sockets.map(({ id, rooms }) => ({ id, rooms: Array.from(rooms) }));

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -5,7 +5,7 @@ export interface RemoteClint {
   rooms: string[];
 }
 
-export const mapFetchedSockets = (
+export const getRemoteClients = (
   sockets: RemoteSocket<{}, unknown>[],
 ): RemoteClint[] =>
   sockets.map(({ id, rooms }) => ({ id, rooms: Array.from(rooms) }));


### PR DESCRIPTION
This will ease the support of namespaces later.