### PR TITLE
Contexts

### DIFF
--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -37,6 +37,8 @@ describe("Action", () => {
     const getAllClientsMock = vi.fn();
     const getDataMock = vi.fn();
     const setDataMock = vi.fn();
+    const joinMock = vi.fn();
+    const leaveMock = vi.fn();
 
     test("should handle simple action", async () => {
       await simpleAction.execute({
@@ -54,6 +56,8 @@ describe("Action", () => {
           isConnected: isConnectedMock,
           getData: getDataMock,
           setData: setDataMock,
+          join: joinMock,
+          leave: leaveMock,
         },
       });
       expect(loggerMock.error).not.toHaveBeenCalled();
@@ -71,6 +75,8 @@ describe("Action", () => {
           getRooms: getRoomsMock,
           getData: getDataMock,
           setData: setDataMock,
+          join: joinMock,
+          leave: leaveMock,
         },
       });
     });
@@ -92,6 +98,8 @@ describe("Action", () => {
           isConnected: isConnectedMock,
           getData: getDataMock,
           setData: setDataMock,
+          join: joinMock,
+          leave: leaveMock,
         },
       });
       expect(loggerMock.error).not.toHaveBeenCalled();
@@ -104,6 +112,8 @@ describe("Action", () => {
           broadcast: broadcastMock,
           getData: getDataMock,
           setData: setDataMock,
+          join: joinMock,
+          leave: leaveMock,
         },
         getAllClients: getAllClientsMock,
         getAllRooms: getAllRoomsMock,
@@ -130,6 +140,8 @@ describe("Action", () => {
           broadcast: broadcastMock,
           getData: getDataMock,
           setData: setDataMock,
+          join: joinMock,
+          leave: leaveMock,
         },
       });
       expect(loggerMock.error).toHaveBeenCalled();

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,38 +1,10 @@
 import { init, last } from "ramda";
-import type { Socket } from "socket.io";
 import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
-import { Broadcaster, EmissionMap, Emitter, RoomService } from "./emission";
+import { Client } from "./client";
+import { EmissionMap, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 import { RemoteClient } from "./remote-client";
-
-export interface Client<E extends EmissionMap> {
-  /** @alias Socket.connected */
-  isConnected: () => boolean;
-  /** @alias Socket.id */
-  id: Socket["id"];
-  /** @desc Returns the list of the rooms the client in */
-  getRooms: () => string[];
-  /**
-   * @desc Sends a new event to the client (this is not acknowledgement)
-   * @throws z.ZodError on validation
-   * @throws Error on ack timeout
-   * */
-  emit: Emitter<E>;
-  /**
-   * @desc Emits to others
-   * @throws z.ZodError on validation
-   * @throws Error on ack timeout
-   * */
-  broadcast: Broadcaster<E>;
-  /** @desc Returns the client metadata according to the specified type or empty object */
-  getData: <D extends object>() => Readonly<Partial<D>>;
-  /**
-   * @desc Sets the client metadata according to the specified type
-   * @throws z.ZodError on validation
-   * */
-  setData: <D extends object>(value: D) => void;
-}
 
 export interface HandlingFeatures<E extends EmissionMap> {
   logger: AbstractLogger;

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,16 +2,14 @@ import { init, last } from "ramda";
 import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
 import { EmissionMap } from "./emission";
-import { ActionContext, Handler } from "./handler";
-
-type CtxNoInput = Omit<ActionContext<never, EmissionMap>, "input">;
+import { ActionContext, ClientContext, Handler } from "./handler";
 
 export abstract class AbstractAction {
   public abstract execute(
     params: {
       event: string;
       params: unknown[];
-    } & CtxNoInput,
+    } & ClientContext<EmissionMap>,
   ): Promise<void>;
 }
 
@@ -71,7 +69,7 @@ export class Action<
   }: {
     event: string;
     params: unknown[];
-  } & CtxNoInput): Promise<void> {
+  } & ClientContext<EmissionMap>): Promise<void> {
     try {
       const input = this.#parseInput(params);
       logger.debug(

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,28 +1,8 @@
 import { init, last } from "ramda";
 import { z } from "zod";
 import { ActionNoAckDef, ActionWithAckDef } from "./actions-factory";
-import { Client } from "./client";
-import { EmissionMap, RoomService } from "./emission";
-import { AbstractLogger } from "./logger";
-import { RemoteClient } from "./remote-client";
-
-export interface HandlingFeatures<E extends EmissionMap> {
-  logger: AbstractLogger;
-  /** @desc The scope of the owner of the received event */
-  client: Client<E>;
-  /** @desc Returns the list of available rooms */
-  getAllRooms: () => string[];
-  /** @desc Returns the list of familiar clients */
-  getAllClients: () => Promise<RemoteClient[]>;
-  /** @desc Provides room(s)-scope methods */
-  withRooms: RoomService<E>;
-}
-
-export type Handler<IN, OUT, E extends EmissionMap> = (
-  params: {
-    input: IN;
-  } & HandlingFeatures<E>,
-) => Promise<OUT>;
+import { EmissionMap } from "./emission";
+import { Handler, HandlingFeatures } from "./handler";
 
 export abstract class AbstractAction {
   public abstract execute(

--- a/src/actions-factory.ts
+++ b/src/actions-factory.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import { Action, Handler } from "./action";
+import { Action } from "./action";
 import { Config } from "./config";
 import { EmissionMap } from "./emission";
+import { Handler } from "./handler";
 
 export interface ActionNoAckDef<
   IN extends z.AnyZodTuple,

--- a/src/actions-factory.ts
+++ b/src/actions-factory.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { Action } from "./action";
 import { Config } from "./config";
 import { EmissionMap } from "./emission";
-import { Handler } from "./handler";
+import { ActionContext, Handler } from "./handler";
 
 export interface ActionNoAckDef<
   IN extends z.AnyZodTuple,
@@ -11,7 +11,7 @@ export interface ActionNoAckDef<
   /** @desc The incoming event payload validation schema (no acknowledgement) */
   input: IN;
   /** @desc No output schema => no returns => no acknowledgement */
-  handler: Handler<z.output<IN>, void, E>;
+  handler: Handler<ActionContext<z.output<IN>, E>, void>;
 }
 
 export interface ActionWithAckDef<
@@ -24,7 +24,7 @@ export interface ActionWithAckDef<
   /** @desc The acknowledgement validation schema */
   output: OUT;
   /** @desc The returns become an Acknowledgement */
-  handler: Handler<z.output<IN>, z.input<OUT>, E>;
+  handler: Handler<ActionContext<z.output<IN>, E>, z.input<OUT>>;
 }
 
 export class ActionsFactory<E extends EmissionMap> {

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -12,6 +12,8 @@ describe("Attach", () => {
       rooms: new Set(["room1", "room2"]),
       on: vi.fn(),
       onAny: vi.fn(),
+      join: vi.fn(),
+      leave: vi.fn(),
     };
     const adapterMock = {
       rooms: new Map([
@@ -93,6 +95,8 @@ describe("Attach", () => {
           broadcast: expect.any(Function),
           getData: expect.any(Function),
           setData: expect.any(Function),
+          join: expect.any(Function),
+          leave: expect.any(Function),
         },
         getAllClients: expect.any(Function),
         getAllRooms: expect.any(Function),
@@ -143,6 +147,21 @@ describe("Attach", () => {
       ).toEqual({
         name: "user",
       });
+
+      // join/leave:
+      for (const rooms of ["room1", ["room2", "room3"]]) {
+        actionsMock.test.execute.mock.lastCall[0].client.join(rooms);
+        expect(socketMock.join).toHaveBeenLastCalledWith(rooms);
+        if (typeof rooms === "string") {
+          actionsMock.test.execute.mock.lastCall[0].client.leave(rooms);
+          expect(socketMock.leave).toHaveBeenLastCalledWith(rooms);
+        } else {
+          await actionsMock.test.execute.mock.lastCall[0].client.leave(rooms);
+          for (const room of rooms) {
+            expect(socketMock.leave).toHaveBeenCalledWith(room);
+          }
+        }
+      }
     });
   });
 });

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import type { Server } from "socket.io";
-import { ActionMap, Handler, HandlingFeatures } from "./action";
+import { ActionMap } from "./action";
 import { Config } from "./config";
 import {
   EmissionMap,
@@ -8,6 +8,7 @@ import {
   makeEmitter,
   makeRoomService,
 } from "./emission";
+import { Handler, HandlingFeatures } from "./handler";
 import { getRemoteClients } from "./remote-client";
 
 export const attachSockets = <E extends EmissionMap>({

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,30 @@
+import type { Socket } from "socket.io";
+import { Broadcaster, EmissionMap, Emitter } from "./emission";
+
+export interface Client<E extends EmissionMap> {
+  /** @alias Socket.connected */
+  isConnected: () => boolean;
+  /** @alias Socket.id */
+  id: Socket["id"];
+  /** @desc Returns the list of the rooms the client in */
+  getRooms: () => string[];
+  /**
+   * @desc Sends a new event to the client (this is not acknowledgement)
+   * @throws z.ZodError on validation
+   * @throws Error on ack timeout
+   * */
+  emit: Emitter<E>;
+  /**
+   * @desc Emits to others
+   * @throws z.ZodError on validation
+   * @throws Error on ack timeout
+   * */
+  broadcast: Broadcaster<E>;
+  /** @desc Returns the client metadata according to the specified type or empty object */
+  getData: <D extends object>() => Readonly<Partial<D>>;
+  /**
+   * @desc Sets the client metadata according to the specified type
+   * @throws z.ZodError on validation
+   * */
+  setData: <D extends object>(value: D) => void;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,4 +27,6 @@ export interface Client<E extends EmissionMap> {
    * @throws z.ZodError on validation
    * */
   setData: <D extends object>(value: D) => void;
+  join: (rooms: string | string[]) => void | Promise<void>;
+  leave: (rooms: string | string[]) => void | Promise<void>;
 }

--- a/src/emission.spec.ts
+++ b/src/emission.spec.ts
@@ -19,7 +19,7 @@ describe("Emission", () => {
   };
 
   const socketMock: Record<
-    "emit" | "timeout" | "emitWithAck" | "join" | "leave",
+    "emit" | "timeout" | "emitWithAck",
     MockedFunction<any>
   > & {
     id: string;
@@ -34,8 +34,6 @@ describe("Emission", () => {
     broadcast: broadcastMock,
     to: vi.fn(() => broadcastMock),
     in: vi.fn(() => broadcastMock),
-    join: vi.fn(),
-    leave: vi.fn(),
   };
   const loggerMock = { debug: vi.fn() };
   const config = {
@@ -86,22 +84,9 @@ describe("Emission", () => {
           config,
         });
         expect(typeof withRooms).toBe("function");
-        const { broadcast, leave, join, getClients } = withRooms(rooms);
+        const { broadcast, getClients } = withRooms(rooms);
         expect(socketMock.to).toHaveBeenLastCalledWith(rooms);
-        for (const method of [broadcast, leave, join]) {
-          expect(typeof method).toBe("function");
-        }
-        join();
-        expect(socketMock.join).toHaveBeenLastCalledWith(rooms);
-        if (typeof rooms === "string") {
-          leave();
-          expect(socketMock.leave).toHaveBeenLastCalledWith(rooms);
-        } else {
-          await leave();
-          for (const room of rooms) {
-            expect(socketMock.leave).toHaveBeenCalledWith(room);
-          }
-        }
+        expect(typeof broadcast).toBe("function");
         await expect(getClients()).resolves.toEqual([
           {
             id: "ID",

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -55,10 +55,7 @@ const makeGenericEmitter =
     assert(event in emission, new Error(`Unsupported event ${event}`));
     const { schema, ack } = emission[event];
     const payload = schema.parse(args);
-    logger.debug(
-      `${isSocket ? "Emitting" : "Broadcasting"} ${String(event)}`,
-      payload,
-    );
+    logger.debug(`Sending ${String(event)}`, payload);
     if (!ack) {
       return target.emit(String(event), ...payload) || true;
     }

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -30,13 +30,11 @@ export type Broadcaster<E extends EmissionMap> = <K extends keyof E>(
 
 export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   /**
-   * @desc Emits an event to everyone in the specified room(s)
+   * @desc Emits an event to others in the specified room(s)
    * @throws z.ZodError on validation
    * @throws Error on ack timeout
    * */
   broadcast: Broadcaster<E>;
-  join: () => void | Promise<void>;
-  leave: () => void | Promise<void>;
   getClients: () => Promise<RemoteClient[]>;
 };
 
@@ -93,11 +91,6 @@ export const makeRoomService =
   (rooms) => ({
     getClients: async () =>
       getRemoteClients(await socket.in(rooms).fetchSockets()),
-    join: () => socket.join(rooms),
-    leave: () =>
-      typeof rooms === "string"
-        ? socket.leave(rooms)
-        : Promise.all(rooms.map((room) => socket.leave(room))).then(() => {}),
     broadcast: makeGenericEmitter({
       ...rest,
       target: socket.to(rooms),

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,22 @@
+import { Client } from "./client";
+import { EmissionMap, RoomService } from "./emission";
+import { AbstractLogger } from "./logger";
+import { RemoteClient } from "./remote-client";
+
+export interface HandlingFeatures<E extends EmissionMap> {
+  logger: AbstractLogger;
+  /** @desc The scope of the owner of the received event */
+  client: Client<E>;
+  /** @desc Returns the list of available rooms */
+  getAllRooms: () => string[];
+  /** @desc Returns the list of familiar clients */
+  getAllClients: () => Promise<RemoteClient[]>;
+  /** @desc Provides room(s)-scope methods */
+  withRooms: RoomService<E>;
+}
+
+export type Handler<IN, OUT, E extends EmissionMap> = (
+  params: {
+    input: IN;
+  } & HandlingFeatures<E>,
+) => Promise<OUT>;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,10 +3,8 @@ import { EmissionMap, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 import { RemoteClient } from "./remote-client";
 
-export interface HandlingFeatures<E extends EmissionMap> {
+interface IndependentContext<E extends EmissionMap> {
   logger: AbstractLogger;
-  /** @desc The scope of the owner of the received event */
-  client: Client<E>;
   /** @desc Returns the list of available rooms */
   getAllRooms: () => string[];
   /** @desc Returns the list of familiar clients */
@@ -15,8 +13,16 @@ export interface HandlingFeatures<E extends EmissionMap> {
   withRooms: RoomService<E>;
 }
 
-export type Handler<IN, OUT, E extends EmissionMap> = (
-  params: {
-    input: IN;
-  } & HandlingFeatures<E>,
-) => Promise<OUT>;
+export interface ClientContext<E extends EmissionMap>
+  extends IndependentContext<E> {
+  /** @desc The sender of the incoming event */
+  client: Client<E>;
+}
+
+export interface ActionContext<IN, E extends EmissionMap>
+  extends ClientContext<E> {
+  /** @desc Validated payload */
+  input: IN;
+}
+
+export type Handler<CTX, OUT> = (params: CTX) => Promise<OUT>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,3 @@ export type { ActionMap } from "./action";
 // issue 952
 export type { EmissionMap } from "./emission";
 export type { LoggerOverrides } from "./logger";
-export { HandlingFeatures } from "./handler";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export type { ActionMap } from "./action";
 // issue 952
 export type { EmissionMap } from "./emission";
 export type { LoggerOverrides } from "./logger";
+export type { Client } from "./client";
+export type { RemoteClient } from "./remote-client";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 export { attachSockets } from "./attach";
 export { createConfig, type Config } from "./config";
 export { ActionsFactory } from "./actions-factory";
-export type { ActionMap, HandlingFeatures } from "./action";
+export type { ActionMap } from "./action";
 
 // issue 952
 export type { EmissionMap } from "./emission";
 export type { LoggerOverrides } from "./logger";
+export { HandlingFeatures } from "./handler";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export type { EmissionMap } from "./emission";
 export type { LoggerOverrides } from "./logger";
 export type { Client } from "./client";
 export type { RemoteClient } from "./remote-client";
+export type { ClientContext } from "./handler";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,4 @@ export type { ActionMap } from "./action";
 // issue 952
 export type { EmissionMap } from "./emission";
 export type { LoggerOverrides } from "./logger";
-export type { Client } from "./client";
-export type { RemoteClient } from "./remote-client";
 export type { ClientContext } from "./handler";


### PR DESCRIPTION
- `join()` and `leave()` moved to `client`.
- Introducing 3 inheriting contexts instead of `HandlingFeatures`
- this should enabling making an independent context for emitting events regardless the Client/Socket