### PR TITLE
Restoring `all` with `all.broadcast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 0
 
+### v0.6.0
+
+- Restoring the `all` argument of the Action handler (removed in v0.4.0), but now it works as expected, by providing:
+  - `getRooms()` — all available rooms,
+  - `getClients()` — all familiar clients,
+  - `broadcast()` — sends an event to everyone.
+
 ### v0.5.0
 
 - Introducing `onStartup` option for `attachSockets()` method:

--- a/example/config.ts
+++ b/example/config.ts
@@ -17,6 +17,9 @@ export const config = createConfig({
     chat: {
       schema: z.tuple([z.string(), z.object({ from: z.string() })]),
     },
+    rooms: {
+      schema: z.tuple([z.string().array()]),
+    },
   },
 });
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -15,4 +15,9 @@ attachSockets({
     subscribe: onSubscribe,
     chat: onChat,
   },
+  onConnection: async ({ client }) => {
+    await client.broadcast("chat", `${client.id} entered the chat`, {
+      from: client.id,
+    });
+  },
 });

--- a/example/index.ts
+++ b/example/index.ts
@@ -20,4 +20,9 @@ attachSockets({
       from: client.id,
     });
   },
+  onStartup: async ({ all }) => {
+    setInterval(() => {
+      all.broadcast("rooms", all.getRooms());
+    }, 30000);
+  },
 });

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -35,6 +35,7 @@ describe("Action", () => {
     const getRoomsMock = vi.fn();
     const getAllRoomsMock = vi.fn();
     const getAllClientsMock = vi.fn();
+    const allBroadcastMock = vi.fn();
     const getDataMock = vi.fn();
     const setDataMock = vi.fn();
     const joinMock = vi.fn();
@@ -46,8 +47,11 @@ describe("Action", () => {
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some"],
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+          broadcast: allBroadcastMock,
+        },
         client: {
           id: "ID",
           emit: emitMock,
@@ -65,8 +69,11 @@ describe("Action", () => {
         input: ["some"],
         logger: loggerMock,
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+          broadcast: allBroadcastMock,
+        },
         client: {
           id: "ID",
           emit: emitMock,
@@ -88,8 +95,11 @@ describe("Action", () => {
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some", ackMock],
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+          broadcast: allBroadcastMock,
+        },
         client: {
           id: "ID",
           emit: emitMock,
@@ -115,8 +125,11 @@ describe("Action", () => {
           join: joinMock,
           leave: leaveMock,
         },
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+          broadcast: allBroadcastMock,
+        },
         withRooms: withRoomsMock,
         input: ["some"],
         logger: loggerMock,
@@ -130,8 +143,11 @@ describe("Action", () => {
         logger: loggerMock as unknown as AbstractLogger,
         params: [], // too short
         withRooms: withRoomsMock,
-        getAllClients: getAllClientsMock,
-        getAllRooms: getAllRoomsMock,
+        all: {
+          getClients: getAllClientsMock,
+          getRooms: getAllRoomsMock,
+          broadcast: allBroadcastMock,
+        },
         client: {
           id: "ID",
           getRooms: getRoomsMock,

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -98,8 +98,11 @@ describe("Attach", () => {
           join: expect.any(Function),
           leave: expect.any(Function),
         },
-        getAllClients: expect.any(Function),
-        getAllRooms: expect.any(Function),
+        all: {
+          getClients: expect.any(Function),
+          getRooms: expect.any(Function),
+          broadcast: expect.any(Function),
+        },
       });
 
       // client.getRooms:
@@ -112,17 +115,17 @@ describe("Attach", () => {
         actionsMock.test.execute.mock.lastCall[0].client.isConnected(),
       ).toBeFalsy();
 
-      // getAllRooms:
-      expect(actionsMock.test.execute.mock.lastCall[0].getAllRooms()).toEqual([
+      // all.getRooms:
+      expect(actionsMock.test.execute.mock.lastCall[0].all.getRooms()).toEqual([
         "room1",
         "room2",
         "room3",
       ]);
       expect(ioMock.of).toHaveBeenLastCalledWith("/");
 
-      // getAllClients:
+      // all.getClients:
       await expect(
-        actionsMock.test.execute.mock.lastCall[0].getAllClients(),
+        actionsMock.test.execute.mock.lastCall[0].all.getClients(),
       ).resolves.toEqual([
         {
           id: "ID",

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -56,14 +56,14 @@ export const attachSockets = async <E extends EmissionMap>({
 }): Promise<Server> => {
   config.logger.info("ZOD-SOCKETS", target.address());
   const rootNS = io.of("/");
-  const getAllRooms = () => Array.from(rootNS.adapter.rooms.keys());
-  const getAllClients = async () =>
-    getRemoteClients(await rootNS.fetchSockets());
   const rootCtx: IndependentContext<E> = {
     logger: config.logger,
-    getAllClients,
-    getAllRooms,
     withRooms: makeRoomService({ subject: io, config }),
+    all: {
+      getClients: async () => getRemoteClients(await rootNS.fetchSockets()),
+      getRooms: () => Array.from(rootNS.adapter.rooms.keys()),
+      broadcast: makeEmitter<Broadcaster<E>>({ subject: io, config }),
+    },
   };
   io.on("connection", async (socket) => {
     const emit = makeEmitter<Emitter<E>>({ subject: socket, config });

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -30,7 +30,7 @@ export type Broadcaster<E extends EmissionMap> = <K extends keyof E>(
 
 export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   /**
-   * @desc Emits an event to all/others in the specified room(s)
+   * @desc Emits an event to all/others (depending on context) in the specified room(s)
    * @throws z.ZodError on validation
    * @throws Error on ack timeout
    * */

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -30,7 +30,7 @@ export type Broadcaster<E extends EmissionMap> = <K extends keyof E>(
 
 export type RoomService<E extends EmissionMap> = (rooms: string | string[]) => {
   /**
-   * @desc Emits an event to others in the specified room(s)
+   * @desc Emits an event to all/others in the specified room(s)
    * @throws z.ZodError on validation
    * @throws Error on ack timeout
    * */
@@ -47,7 +47,7 @@ export const makeEmitter = <T>({
   config: { logger, emission, timeout },
 }: {
   config: Config<EmissionMap>;
-  subject: Socket | Socket["broadcast"];
+  subject: Socket | Socket["broadcast"] | Server;
 }) =>
   (async (event: string, ...args: unknown[]) => {
     const isSocket = "id" in subject;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,14 +1,18 @@
 import { Client } from "./client";
-import { EmissionMap, RoomService } from "./emission";
+import { Broadcaster, EmissionMap, RoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 import { RemoteClient } from "./remote-client";
 
 export interface IndependentContext<E extends EmissionMap> {
   logger: AbstractLogger;
-  /** @desc Returns the list of available rooms */
-  getAllRooms: () => string[];
-  /** @desc Returns the list of familiar clients */
-  getAllClients: () => Promise<RemoteClient[]>;
+  all: {
+    /** @desc Returns the list of available rooms */
+    getRooms: () => string[];
+    /** @desc Returns the list of familiar clients */
+    getClients: () => Promise<RemoteClient[]>;
+    /** @desc Emits an event to everyone */
+    broadcast: Broadcaster<E>;
+  };
   /** @desc Provides room(s)-scope methods */
   withRooms: RoomService<E>;
 }


### PR DESCRIPTION
Reverts #22 now properly