### PR TITLE
Generic distribution methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0
 
+### v0.6.1
+
+- Adding `join()` and `leave()` methods to `RemoteClient` (the ones returned by `getClients()`).
+
 ### v0.6.0
 
 - Restoring the `all` argument of the Action handler (removed in v0.4.0), but now it works as expected, by providing:

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -28,8 +28,18 @@ describe("Attach", () => {
       of: vi.fn(() => ({
         adapter: adapterMock,
         fetchSockets: vi.fn(async () => [
-          { id: "ID", rooms: new Set(["room1", "room2"]) },
-          { id: "other", rooms: new Set(["room3"]) },
+          {
+            id: "ID",
+            rooms: new Set(["room1", "room2"]),
+            join: vi.fn(),
+            leave: vi.fn(),
+          },
+          {
+            id: "other",
+            rooms: new Set(["room3"]),
+            join: vi.fn(),
+            leave: vi.fn(),
+          },
         ]),
       })),
     };
@@ -131,11 +141,15 @@ describe("Attach", () => {
           id: "ID",
           rooms: ["room1", "room2"],
           getData: expect.any(Function),
+          join: expect.any(Function),
+          leave: expect.any(Function),
         },
         {
           id: "other",
           rooms: ["room3"],
           getData: expect.any(Function),
+          join: expect.any(Function),
+          leave: expect.any(Function),
         },
       ]);
 

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -3,6 +3,7 @@ import type { Server } from "socket.io";
 import { ActionMap } from "./action";
 import { Client } from "./client";
 import { Config } from "./config";
+import { makeDistribution } from "./distribution";
 import {
   Broadcaster,
   EmissionMap,
@@ -79,11 +80,7 @@ export const attachSockets = async <E extends EmissionMap>({
       getRooms: () => Array.from(socket.rooms),
       getData: () => socket.data || {},
       setData: (value) => (socket.data = value),
-      join: socket.join,
-      leave: (rooms) =>
-        typeof rooms === "string"
-          ? socket.leave(rooms)
-          : Promise.all(rooms.map((room) => socket.leave(room))).then(() => {}),
+      ...makeDistribution(socket),
     };
     const ctx: ClientContext<E> = {
       ...rootCtx,

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -79,7 +79,7 @@ export const attachSockets = async <E extends EmissionMap>({
       getRooms: () => Array.from(socket.rooms),
       getData: () => socket.data || {},
       setData: (value) => (socket.data = value),
-      join: (rooms) => socket.join(rooms),
+      join: socket.join,
       leave: (rooms) =>
         typeof rooms === "string"
           ? socket.leave(rooms)

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,8 @@
 import type { Socket } from "socket.io";
+import { Distribution } from "./distribution";
 import { Broadcaster, EmissionMap, Emitter } from "./emission";
 
-export interface Client<E extends EmissionMap> {
+export interface Client<E extends EmissionMap> extends Distribution {
   /** @alias Socket.connected */
   isConnected: () => boolean;
   /** @alias Socket.id */
@@ -27,6 +28,4 @@ export interface Client<E extends EmissionMap> {
    * @throws z.ZodError on validation
    * */
   setData: <D extends object>(value: D) => void;
-  join: (rooms: string | string[]) => void | Promise<void>;
-  leave: (rooms: string | string[]) => void | Promise<void>;
 }

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -8,7 +8,7 @@ export interface Distribution {
 export const makeDistribution = (
   subject: Socket | RemoteSocket<{}, unknown>,
 ): Distribution => ({
-  join: subject.join,
+  join: subject.join.bind(subject),
   leave: (rooms) =>
     typeof rooms === "string"
       ? subject.leave(rooms)

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -1,0 +1,16 @@
+import { RemoteSocket, Socket } from "socket.io";
+
+export interface Distribution {
+  join: (rooms: string | string[]) => void | Promise<void>;
+  leave: (rooms: string | string[]) => void | Promise<void>;
+}
+
+export const makeDistribution = (
+  subject: Socket | RemoteSocket<{}, unknown>,
+): Distribution => ({
+  join: subject.join,
+  leave: (rooms) =>
+    typeof rooms === "string"
+      ? subject.leave(rooms)
+      : Promise.all(rooms.map((room) => subject.leave(room))).then(() => {}),
+});

--- a/src/emission.spec.ts
+++ b/src/emission.spec.ts
@@ -13,8 +13,13 @@ describe("Emission", () => {
     timeout: vi.fn(() => broadcastMock),
     emitWithAck: vi.fn(),
     fetchSockets: vi.fn(async () => [
-      { id: "ID", rooms: new Set(["room1", "room2"]) },
-      { id: "other", rooms: new Set(["room3"]) },
+      {
+        id: "ID",
+        rooms: new Set(["room1", "room2"]),
+        join: vi.fn(),
+        leave: vi.fn(),
+      },
+      { id: "other", rooms: new Set(["room3"]), join: vi.fn(), leave: vi.fn() },
     ]),
   };
 
@@ -94,11 +99,15 @@ describe("Emission", () => {
             id: "ID",
             rooms: ["room1", "room2"],
             getData: expect.any(Function),
+            join: expect.any(Function),
+            leave: expect.any(Function),
           },
           {
             id: "other",
             rooms: ["room3"],
             getData: expect.any(Function),
+            join: expect.any(Function),
+            leave: expect.any(Function),
           },
         ]);
       },

--- a/src/remote-client.spec.ts
+++ b/src/remote-client.spec.ts
@@ -1,26 +1,38 @@
 import { RemoteSocket } from "socket.io";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { getRemoteClients } from "./remote-client";
 
 describe("RemoteClient", () => {
   describe("getRemoteClients()", () => {
     const socketsMock = [
-      { id: "ONE", rooms: new Set(["room1"]), data: { name: "TEST" } },
-      { id: "TWO", rooms: new Set(["room2"]) },
+      {
+        id: "ONE",
+        rooms: new Set(["room1"]),
+        data: { name: "TEST" },
+        join: vi.fn(),
+        leave: vi.fn(),
+      },
+      { id: "TWO", rooms: new Set(["room2"]), join: vi.fn(), leave: vi.fn() },
     ];
 
     test("should map RemoteSockets to RemoteClients", () => {
-      const clients = getRemoteClients(socketsMock as RemoteSocket<any, any>[]);
+      const clients = getRemoteClients(
+        socketsMock as unknown as RemoteSocket<any, any>[],
+      );
       expect(clients).toEqual([
         {
           id: "ONE",
           rooms: ["room1"],
           getData: expect.any(Function),
+          join: expect.any(Function),
+          leave: expect.any(Function),
         },
         {
           id: "TWO",
           rooms: ["room2"],
           getData: expect.any(Function),
+          join: expect.any(Function),
+          leave: expect.any(Function),
         },
       ]);
 

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -4,11 +4,13 @@ export interface RemoteClient {
   id: string;
   rooms: string[];
   getData: <D extends object>() => Readonly<Partial<D>>;
+  join: (rooms: string | string[]) => void | Promise<void>;
 }
 
 export const getRemoteClients = (sockets: RemoteSocket<{}, unknown>[]) =>
-  sockets.map<RemoteClient>(({ id, rooms, data }) => ({
+  sockets.map<RemoteClient>(({ id, rooms, data, join }) => ({
     id: id,
     rooms: Array.from(rooms),
     getData: <D extends object>() => (data as D) || {},
+    join,
   }));

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,16 +1,17 @@
 import { RemoteSocket } from "socket.io";
 
-export interface RemoteClient {
+import { Distribution, makeDistribution } from "./distribution";
+
+export interface RemoteClient extends Distribution {
   id: string;
   rooms: string[];
   getData: <D extends object>() => Readonly<Partial<D>>;
-  join: (rooms: string | string[]) => void | Promise<void>;
 }
 
 export const getRemoteClients = (sockets: RemoteSocket<{}, unknown>[]) =>
-  sockets.map<RemoteClient>(({ id, rooms, data, join }) => ({
-    id: id,
-    rooms: Array.from(rooms),
-    getData: <D extends object>() => (data as D) || {},
-    join,
+  sockets.map<RemoteClient>((socket) => ({
+    id: socket.id,
+    rooms: Array.from(socket.rooms),
+    getData: <D extends object>() => (socket.data as D) || {},
+    ...makeDistribution(socket),
   }));


### PR DESCRIPTION
adds `join` and `leave` to RemoteClient as well.