### PR TITLE
Ref: overloads for `makeEmitter()`

### DIFF
--- a/src/attach.ts
+++ b/src/attach.ts
@@ -69,10 +69,7 @@ export const attachSockets = async <E extends EmissionMap>({
   };
   io.on("connection", async (socket) => {
     const emit = makeEmitter({ subject: socket, ...emitCfg });
-    const broadcast = makeEmitter({
-      subject: socket.broadcast,
-      ...emitCfg,
-    });
+    const broadcast = makeEmitter({ subject: socket.broadcast, ...emitCfg });
     const client: Client<E> = {
       emit,
       broadcast,

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -5,9 +5,7 @@ import { Client } from "./client";
 import { Config } from "./config";
 import { makeDistribution } from "./distribution";
 import {
-  Broadcaster,
   EmissionMap,
-  Emitter,
   EmitterConfig,
   makeEmitter,
   makeRoomService,
@@ -66,12 +64,12 @@ export const attachSockets = async <E extends EmissionMap>({
     all: {
       getClients: async () => getRemoteClients(await rootNS.fetchSockets()),
       getRooms: () => Array.from(rootNS.adapter.rooms.keys()),
-      broadcast: makeEmitter<Broadcaster<E>>({ subject: io, ...emitCfg }),
+      broadcast: makeEmitter({ subject: io, ...emitCfg }),
     },
   };
   io.on("connection", async (socket) => {
-    const emit = makeEmitter<Emitter<E>>({ subject: socket, ...emitCfg });
-    const broadcast = makeEmitter<Broadcaster<E>>({
+    const emit = makeEmitter({ subject: socket, ...emitCfg });
+    const broadcast = makeEmitter({
       subject: socket.broadcast,
       ...emitCfg,
     });

--- a/src/emission.spec.ts
+++ b/src/emission.spec.ts
@@ -1,7 +1,7 @@
 import { Socket } from "socket.io";
 import { MockedFunction, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { Broadcaster, Emitter, makeEmitter, makeRoomService } from "./emission";
+import { makeEmitter, makeRoomService } from "./emission";
 import { AbstractLogger } from "./logger";
 
 describe("Emission", () => {

--- a/src/emission.spec.ts
+++ b/src/emission.spec.ts
@@ -55,7 +55,7 @@ describe("Emission", () => {
       { name: "socket", subject: socketMock, ack: ["test"] },
       { name: "broadcast", subject: broadcastMock, ack: [["test"]] },
     ])("with $name", ({ subject, ack }) => {
-      const emitter = makeEmitter<Emitter<any> | Broadcaster<any>>({
+      const emitter = makeEmitter({
         subject: subject as unknown as Socket,
         ...emitCfg,
       });


### PR DESCRIPTION
Much better way to organize things