### PR TITLE
Simple config and opt-in namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Version 0
 
+### v0.13.0
+
+- Config creation changes aim to improve the clarity and make it easier to begin using this library for the first time;
+- Easier config for a simple applications:
+  - Replacing `createConfig()` with `createSimpleConfig()` - for a single namespace (root namespace only).
+- Making namespaces opt-in feature:
+  - Use the exposed `new Config()` and its `.addNamespace()` method of each namespace;
+  - Fallbacks removed from `Config::constructor` — it creates no namespaces by default,
+    but `addNamespace` creates root namespace when `path` prop is omitted;
+- See the migration advice below.
+
+```ts
+// if using the root namespace only:
+import { createSimpleConfig } from "zod-sockets";
+const simpleConfig = createSimpleConfig({
+  logger,
+  timeout,
+  emission,
+  hooks,
+  metadata,
+});
+
+// if using namespaces other than "/":
+import { Config } from "zod-sockets";
+const config = new Config({ logger, timeout })
+  .addNamespace({
+    path: "ns1",
+    emission,
+    hooks,
+    metadata,
+  })
+  .addNamespace({
+    path: "ns2",
+    emission,
+    hooks,
+    metadata,
+  });
+```
+
 ### v0.12.0
 
 - Switching to AsyncAPI version 3.0.0 for generating documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,7 @@
 // if using the root namespace only:
 import { createSimpleConfig } from "zod-sockets";
 const simpleConfig = createSimpleConfig({
-  logger,
-  timeout,
-  emission,
-  hooks,
-  metadata,
+  /* logger, timeout, emission, hooks, metadata */
 });
 
 // if using namespaces other than "/":
@@ -29,15 +25,11 @@ import { Config } from "zod-sockets";
 const config = new Config({ logger, timeout })
   .addNamespace({
     path: "ns1",
-    emission,
-    hooks,
-    metadata,
+    /* emission, hooks, metadata */
   })
   .addNamespace({
     path: "ns2",
-    emission,
-    hooks,
-    metadata,
+    /* emission, hooks, metadata */
   });
 ```
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Please avoid transformations in those schemas since they are not going to be app
 
 ```typescript
 import { z } from "zod";
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
 const config = createSimpleConfig({
   metadata: z.object({

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ yarn add zod-sockets zod socket.io typescript
 ```typescript
 import { createSimpleConfig } from "zod-sockets";
 
-const config = createSimpleConfig(); // shorthand for root namespace only
+// shorthand for root namespace only, defaults: console logger, timeout 2s
+const config = createSimpleConfig();
 ```
 
 ## Create a factory

--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ yarn add zod-sockets zod socket.io typescript
 ## Set up config
 
 ```typescript
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
-// defaults: root namespace only, console logger, timeout 2s
-const config = new Config();
+const config = createSimpleConfig(); // shorthand for root namespace only
 ```
 
 ## Create a factory
@@ -111,36 +110,6 @@ for sending the `ping` event to `ws://localhost:8090` with acknowledgement.
 
 # Basic features
 
-## Namespaces first
-
-Namespaces allow you to separate incoming and outgoing events into groups, in which events can have the same name, but
-different essence, payload and handlers. You can add `namespaces` to the argument of `new Config()` or use its method
-`addNamespace()` next to it. The default namespace is a root one having `path` equal to `/`. Namespaces may have
-`emission` and `hooks`.
-Read the Socket.IO [documentation on namespaces](https://socket.io/docs/v4/namespaces/).
-
-```typescript
-import { Config } from "zod-sockets";
-
-const config = new Config({
-  namespaces: {
-    // The namespace "/public"
-    public: {
-      emission: { chat: { schema } },
-      hooks: {
-        onStartup: () => {},
-        onConnection: () => {},
-        onDisconnect: () => {},
-        onAnyIncoming: () => {},
-        onAnyOutgoing: () => {},
-      },
-    },
-  },
-}).addNamespace({
-  path: "private", // The namespace "/private" has no emission
-});
-```
-
 ## Emission
 
 The outgoing events should be configured using `z.tuple()` schemas. Those tuples describe the types of the arguments
@@ -151,10 +120,9 @@ development. Consider the following examples of two outgoing events, with and wi
 
 ```typescript
 import { z } from "zod";
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
-const config = new Config().addNamespace({
-  // path: "/", // optional, default: root namespace
+const config = createSimpleConfig({
   emission: {
     // enabling Socket::emit("chat", "message", { from: "someone" })
     chat: {
@@ -222,7 +190,7 @@ The library supports any logger having `info()`, `debug()`, `error()` and
 
 ```typescript
 import pino, { Logger } from "pino";
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
 const logger = pino({
   transport: {
@@ -230,7 +198,7 @@ const logger = pino({
     options: { colorize: true },
   },
 });
-const config = new Config({ logger });
+const config = createSimpleConfig({ logger });
 
 // Setting the type of logger used
 declare module "zod-sockets" {
@@ -246,11 +214,11 @@ configs of both libraries. In case you're using the default `winston` logger pro
 
 ```typescript
 import { createServer } from "express-zod-api";
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 import type { Logger } from "winston";
 
 const { logger } = await createServer();
-const config = new Config({ logger });
+const config = createSimpleConfig({ logger });
 
 // Setting the type of logger used
 declare module "zod-sockets" {
@@ -342,9 +310,9 @@ emit events regardless the incoming ones by setting the `onConnection` property 
 argument, which has a similar interface except `input` and fires for every connected client:
 
 ```typescript
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
-const config = new Config().addNamespace({
+const config = createSimpleConfig({
   // emission: { ... },
   hooks: {
     onConnection: async ({ client, withRooms, all }) => {
@@ -360,9 +328,9 @@ Moreover, you can emit events regardless the client activity at all by setting t
 of the `addNamespace()` argument. The implementation may have a `setInterval()` for recurring emission.
 
 ```typescript
-import { Config } from "zod-sockets";
+import { createSimpleConfig } from "zod-sockets";
 
-const config = new Config().addNamespace({
+const config = createSimpleConfig({
   hooks: {
     onStartup: async ({ all, withRooms }) => {
       // sending to everyone in a room
@@ -442,7 +410,7 @@ Please avoid transformations in those schemas since they are not going to be app
 import { z } from "zod";
 import { Config } from "zod-sockets";
 
-const config = new Config().addNamespace({
+const config = createSimpleConfig({
   metadata: z.object({
     /** @desc Number of messages sent to the chat */
     msgCount: z.number().int(),
@@ -473,6 +441,36 @@ assistance of its argument and may throw `ZodError` if it does not pass the vali
 const handler = async ({ client }) => {
   client.setData({ msgCount: 4 });
 };
+```
+
+## Namespaces
+
+Namespaces allow you to separate incoming and outgoing events into groups, in which events can have the same name, but
+different essence, payload and handlers. For using namespaces replace the `createSimpleConfig()` method with
+`new Config()`, then use its `.addNamespace()` method for each namespace. Namespaces may have `emission` and `hooks`.
+Read the Socket.IO [documentation on namespaces](https://socket.io/docs/v4/namespaces/).
+
+```typescript
+import { Config } from "zod-sockets";
+
+const config = new Config({
+  logger,
+  timeout: 2000,
+})
+  .addNamespace({
+    // The namespace "/public"
+    emission: { chat: { schema } },
+    hooks: {
+      onStartup: () => {},
+      onConnection: () => {},
+      onDisconnect: () => {},
+      onAnyIncoming: () => {},
+      onAnyOutgoing: () => {},
+    },
+  })
+  .addNamespace({
+    path: "private", // The namespace "/private" has no emission
+  });
 ```
 
 # Integration

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ yarn add zod-sockets zod socket.io typescript
 ## Set up config
 
 ```typescript
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
 // defaults: root namespace only, console logger, timeout 2s
-const config = createConfig();
+const config = new Config();
 ```
 
 ## Create a factory
@@ -114,15 +114,15 @@ for sending the `ping` event to `ws://localhost:8090` with acknowledgement.
 ## Namespaces first
 
 Namespaces allow you to separate incoming and outgoing events into groups, in which events can have the same name, but
-different essence, payload and handlers. You can add `namespaces` to the argument of `createConfig()` or use
-`addNamespace()` method after it. The default namespace is a root one having `path` equal to `/`. Namespaces may have
+different essence, payload and handlers. You can add `namespaces` to the argument of `new Config()` or use its method
+`addNamespace()` next to it. The default namespace is a root one having `path` equal to `/`. Namespaces may have
 `emission` and `hooks`.
 Read the Socket.IO [documentation on namespaces](https://socket.io/docs/v4/namespaces/).
 
 ```typescript
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
-const config = createConfig({
+const config = new Config({
   namespaces: {
     // The namespace "/public"
     public: {
@@ -151,9 +151,9 @@ development. Consider the following examples of two outgoing events, with and wi
 
 ```typescript
 import { z } from "zod";
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
-const config = createConfig().addNamespace({
+const config = new Config().addNamespace({
   // path: "/", // optional, default: root namespace
   emission: {
     // enabling Socket::emit("chat", "message", { from: "someone" })
@@ -222,7 +222,7 @@ The library supports any logger having `info()`, `debug()`, `error()` and
 
 ```typescript
 import pino, { Logger } from "pino";
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
 const logger = pino({
   transport: {
@@ -230,7 +230,7 @@ const logger = pino({
     options: { colorize: true },
   },
 });
-const config = createConfig({ logger });
+const config = new Config({ logger });
 
 // Setting the type of logger used
 declare module "zod-sockets" {
@@ -241,16 +241,16 @@ declare module "zod-sockets" {
 ### With Express Zod API
 
 If you're using `express-zod-api`, you can reuse the same logger. If it's a custom logger — supply the same instance to
-both `createConfig()` methods of two libraries. In case you're using the default `winston` logger provided by
+configs of both libraries. In case you're using the default `winston` logger provided by
 `express-zod-api`, you can obtain its instance from the returns of the `createServer()` method.
 
 ```typescript
 import { createServer } from "express-zod-api";
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 import type { Logger } from "winston";
 
 const { logger } = await createServer();
-const config = createConfig({ logger });
+const config = new Config({ logger });
 
 // Setting the type of logger used
 declare module "zod-sockets" {
@@ -342,9 +342,9 @@ emit events regardless the incoming ones by setting the `onConnection` property 
 argument, which has a similar interface except `input` and fires for every connected client:
 
 ```typescript
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
-const config = createConfig().addNamespace({
+const config = new Config().addNamespace({
   // emission: { ... },
   hooks: {
     onConnection: async ({ client, withRooms, all }) => {
@@ -360,9 +360,9 @@ Moreover, you can emit events regardless the client activity at all by setting t
 of the `addNamespace()` argument. The implementation may have a `setInterval()` for recurring emission.
 
 ```typescript
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
-const config = createConfig().addNamespace({
+const config = new Config().addNamespace({
   hooks: {
     onStartup: async ({ all, withRooms }) => {
       // sending to everyone in a room
@@ -440,9 +440,9 @@ Please avoid transformations in those schemas since they are not going to be app
 
 ```typescript
 import { z } from "zod";
-import { createConfig } from "zod-sockets";
+import { Config } from "zod-sockets";
 
-const config = createConfig().addNamespace({
+const config = new Config().addNamespace({
   metadata: z.object({
     /** @desc Number of messages sent to the chat */
     msgCount: z.number().int(),

--- a/example/config.ts
+++ b/example/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { Config } from "../src";
+import { createSimpleConfig } from "../src";
 
-export const config = new Config().addNamespace({
+export const config = createSimpleConfig({
   emission: {
     time: {
       schema: z.tuple([

--- a/example/config.ts
+++ b/example/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { createConfig } from "../src";
+import { Config } from "../src";
 
-export const config = createConfig().addNamespace({
+export const config = new Config().addNamespace({
   emission: {
     time: {
       schema: z.tuple([

--- a/src/actions-factory.spec.ts
+++ b/src/actions-factory.spec.ts
@@ -2,17 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { Action } from "./action";
 import { ActionsFactory } from "./actions-factory";
-import { createConfig } from "./config";
-import { AbstractLogger } from "./logger";
+import { Config } from "./config";
 
 describe("ActionsFactory", () => {
-  const factory = new ActionsFactory(
-    createConfig({
-      namespaces: {},
-      timeout: 2000,
-      logger: { debug: vi.fn() } as unknown as AbstractLogger,
-    }),
-  );
+  const factory = new ActionsFactory(new Config());
 
   describe("constructor", () => {
     test("should create a factory", () => {
@@ -24,7 +17,7 @@ describe("ActionsFactory", () => {
         factory.build({
           event: "test",
           input: z.tuple([z.string()]),
-          handler: vi.fn(),
+          handler: vi.fn<any>(),
         }),
       ).toBeInstanceOf(Action);
     });

--- a/src/actions-factory.spec.ts
+++ b/src/actions-factory.spec.ts
@@ -2,10 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { Action } from "./action";
 import { ActionsFactory } from "./actions-factory";
-import { Config } from "./config";
+import { createSimpleConfig } from "./config";
 
 describe("ActionsFactory", () => {
-  const factory = new ActionsFactory(new Config());
+  const factory = new ActionsFactory(createSimpleConfig());
 
   describe("constructor", () => {
     test("should create a factory", () => {

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -3,7 +3,7 @@ import { Server } from "socket.io";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { attachSockets } from "./attach";
-import { createConfig } from "./config";
+import { Config } from "./config";
 import { AbstractLogger } from "./logger";
 
 describe("Attach", () => {
@@ -67,7 +67,7 @@ describe("Attach", () => {
         io: ioMock as unknown as Server,
         target: targetMock as unknown as http.Server,
         actions: actionsMock,
-        config: createConfig({
+        config: new Config({
           startupLogo: false,
           timeout: 100,
           namespaces: {

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -3,7 +3,7 @@ import { Server } from "socket.io";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { attachSockets } from "./attach";
-import { Config } from "./config";
+import { createSimpleConfig } from "./config";
 import { AbstractLogger } from "./logger";
 
 describe("Attach", () => {
@@ -67,16 +67,12 @@ describe("Attach", () => {
         io: ioMock as unknown as Server,
         target: targetMock as unknown as http.Server,
         actions: actionsMock,
-        config: new Config({
+        config: createSimpleConfig({
           startupLogo: false,
           timeout: 100,
-          namespaces: {
-            "/": {
-              emission: {},
-              hooks,
-              metadata: z.object({ name: z.string() }),
-            },
-          },
+          emission: {},
+          hooks,
+          metadata: z.object({ name: z.string() }),
           logger: loggerMock as unknown as AbstractLogger,
         }),
       });

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -55,5 +55,10 @@ describe("Config", () => {
         },
       });
     });
+
+    test("should allow to disable root namespace", () => {
+      const config = new Config({ namespaces: {} });
+      expect(config.namespaces).toEqual({});
+    });
   });
 });

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { Config, createConfig } from "./config";
+import { Config } from "./config";
 import { AbstractLogger } from "./logger";
 
 describe("Config", () => {
   describe("createConfig()", () => {
     test("should create config without any argument", () => {
-      const config = createConfig();
+      const config = new Config();
       expect(config).toBeInstanceOf(Config);
       expect(config.logger).toEqual(console);
       expect(config.timeout).toBe(2000);
@@ -16,7 +16,7 @@ describe("Config", () => {
     });
 
     test("should create the class instance from the definition", () => {
-      const config = createConfig({
+      const config = new Config({
         namespaces: {
           "/": { emission: {}, hooks: {}, metadata: z.object({}) },
           test: { emission: {}, hooks: {}, metadata: z.object({}) },
@@ -34,7 +34,7 @@ describe("Config", () => {
     });
 
     test("should set defaults and provide namespace augmentation method", () => {
-      const base = createConfig({});
+      const base = new Config({});
       expect(base).toBeInstanceOf(Config);
       expect(base.logger).toEqual(console);
       expect(base.timeout).toBe(2000);

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { ZodObject, z } from "zod";
+import { z } from "zod";
 import { Config, createSimpleConfig } from "./config";
 import { AbstractLogger } from "./logger";
 
@@ -30,9 +30,11 @@ describe("Config", () => {
         test: { emission: {}, hooks: {}, metadata: expect.any(z.ZodObject) },
       });
     });
+  });
 
+  describe(".addNamespace()", () => {
     test("should provide namespace augmentation method", () => {
-      const base = new Config({});
+      const base = new Config();
       expect(base).toBeInstanceOf(Config);
       expect(base.logger).toEqual(console);
       expect(base.timeout).toBe(2000);
@@ -51,11 +53,6 @@ describe("Config", () => {
         },
       });
     });
-
-    test("should allow to disable root namespace", () => {
-      const config = new Config({ namespaces: {} });
-      expect(config.namespaces).toEqual({});
-    });
   });
 
   describe("createSimpleConfig()", () => {
@@ -65,7 +62,7 @@ describe("Config", () => {
       expect(config.logger).toEqual(console);
       expect(config.timeout).toBe(2000);
       expect(config.namespaces).toEqual({
-        "/": { emission: {}, hooks: {}, metadata: expect.any(ZodObject) },
+        "/": { emission: {}, hooks: {}, metadata: expect.any(z.ZodObject) },
       });
     });
 
@@ -81,7 +78,7 @@ describe("Config", () => {
       expect(config.logger).not.toEqual(console);
       expect(config.timeout).toBe(3000);
       expect(config.namespaces).toEqual({
-        "/": { emission: {}, hooks: {}, metadata: expect.any(ZodObject) },
+        "/": { emission: {}, hooks: {}, metadata: expect.any(z.ZodObject) },
       });
     });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,7 @@
 import { z } from "zod";
 import { EmissionMap } from "./emission";
 import { AbstractLogger } from "./logger";
-import {
-  FallbackNamespaces,
-  Namespace,
-  Namespaces,
-  RootNS,
-  fallbackNamespaces,
-  rootNS,
-} from "./namespace";
+import { Namespace, Namespaces, RootNS, rootNS } from "./namespace";
 
 interface ConstructorOptions<NS extends Namespaces> {
   /**
@@ -28,13 +21,13 @@ interface ConstructorOptions<NS extends Namespaces> {
   startupLogo?: boolean;
   /**
    * @desc Define namespaces inline or consider using addNamespace() method
-   * @default fallbackNamespaces
-   * @see fallbackNamespaces
+   * @default {}
+   * @see Namespaces
    * */
   namespaces?: NS;
 }
 
-export class Config<T extends Namespaces = FallbackNamespaces> {
+export class Config<T extends Namespaces = {}> {
   public readonly logger: AbstractLogger;
   public readonly timeout: number;
   public readonly startupLogo: boolean;
@@ -44,7 +37,7 @@ export class Config<T extends Namespaces = FallbackNamespaces> {
     logger = console,
     timeout = 2000,
     startupLogo = true,
-    namespaces = fallbackNamespaces as unknown as T,
+    namespaces = {} as T,
   }: ConstructorOptions<T> = {}) {
     this.logger = logger;
     this.timeout = timeout;
@@ -73,3 +66,22 @@ export class Config<T extends Namespaces = FallbackNamespaces> {
     });
   }
 }
+
+/** @desc Shorthand for single namespace config (root namespace only) */
+export const createSimpleConfig = <
+  E extends EmissionMap,
+  D extends z.SomeZodObject,
+>({
+  startupLogo,
+  timeout,
+  logger,
+  emission,
+  hooks,
+  metadata,
+}: Omit<ConstructorOptions<never>, "namespaces"> &
+  Partial<Namespace<E, D>> = {}) =>
+  new Config({ startupLogo, timeout, logger }).addNamespace({
+    emission,
+    metadata,
+    hooks,
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ interface ConstructorOptions<NS extends Namespaces> {
   /**
    * @desc Define namespaces inline or consider using addNamespace() method
    * @default {}
-   * @see Namespaces
+   * @see Namespace
    * */
   namespaces?: NS;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,13 +28,13 @@ interface ConstructorOptions<NS extends Namespaces> {
   startupLogo?: boolean;
   /**
    * @desc Define namespaces inline or consider using addNamespace() method
-   * @default {}
-   * @see Namespace
+   * @default fallbackNamespaces
+   * @see fallbackNamespaces
    * */
   namespaces?: NS;
 }
 
-export class Config<T extends Namespaces> {
+export class Config<T extends Namespaces = FallbackNamespaces> {
   public readonly logger: AbstractLogger;
   public readonly timeout: number;
   public readonly startupLogo: boolean;
@@ -45,7 +45,7 @@ export class Config<T extends Namespaces> {
     timeout = 2000,
     startupLogo = true,
     namespaces = fallbackNamespaces as unknown as T,
-  }: ConstructorOptions<T>) {
+  }: ConstructorOptions<T> = {}) {
     this.logger = logger;
     this.timeout = timeout;
     this.startupLogo = startupLogo;
@@ -73,7 +73,3 @@ export class Config<T extends Namespaces> {
     });
   }
 }
-
-export const createConfig = <T extends Namespaces = FallbackNamespaces>(
-  def: ConstructorOptions<T> = {},
-) => new Config(def);

--- a/src/documentation.spec.ts
+++ b/src/documentation.spec.ts
@@ -2,14 +2,14 @@ import { SchemaObject } from "openapi3-ts/oas31";
 import { config as exampleConfig } from "../example/config";
 import { actions } from "../example/actions";
 import { ActionsFactory } from "./actions-factory";
-import { createConfig } from "./config";
+import { Config } from "./config";
 import { Documentation } from "./documentation";
 import { z } from "zod";
 import { describe, expect, test, vi } from "vitest";
 import { protocol } from "engine.io";
 
 describe("Documentation", () => {
-  const sampleConfig = createConfig();
+  const sampleConfig = new Config();
   const factory = new ActionsFactory(sampleConfig);
 
   describe("Basic cases", () => {

--- a/src/documentation.spec.ts
+++ b/src/documentation.spec.ts
@@ -2,14 +2,14 @@ import { SchemaObject } from "openapi3-ts/oas31";
 import { config as exampleConfig } from "../example/config";
 import { actions } from "../example/actions";
 import { ActionsFactory } from "./actions-factory";
-import { Config } from "./config";
+import { createSimpleConfig } from "./config";
 import { Documentation } from "./documentation";
 import { z } from "zod";
 import { describe, expect, test, vi } from "vitest";
 import { protocol } from "engine.io";
 
 describe("Documentation", () => {
-  const sampleConfig = new Config();
+  const sampleConfig = createSimpleConfig();
   const factory = new ActionsFactory(sampleConfig);
 
   describe("Basic cases", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { attachSockets } from "./attach";
-export { createConfig, type Config } from "./config";
+export { Config } from "./config";
 export { ActionsFactory } from "./actions-factory";
 export { AbstractAction } from "./action";
 export { Integration } from "./integration";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { attachSockets } from "./attach";
-export { Config } from "./config";
+export { Config, createSimpleConfig } from "./config";
 export { ActionsFactory } from "./actions-factory";
 export { AbstractAction } from "./action";
 export { Integration } from "./integration";

--- a/src/namespace.spec.ts
+++ b/src/namespace.spec.ts
@@ -1,20 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { z } from "zod";
-import { fallbackNamespaces, normalizeNS, rootNS } from "./namespace";
+import { normalizeNS, rootNS } from "./namespace";
 
 describe("Namespace", () => {
   describe("rootNS", () => {
     test("should be slash", () => {
       expect(rootNS).toBe("/");
-    });
-  });
-
-  describe("fallbackNamespaces", () => {
-    test("should consist of the empty root namespace", () => {
-      expect(fallbackNamespaces).toEqual({
-        "/": { emission: {}, hooks: {}, metadata: expect.any(z.ZodObject) },
-      });
-      expect(fallbackNamespaces[rootNS].metadata.shape).toEqual({});
     });
   });
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -32,12 +32,3 @@ export type Namespaces = Record<
   string,
   Namespace<EmissionMap, z.SomeZodObject>
 >;
-
-export const fallbackNamespaces = {
-  [rootNS]: {
-    emission: {},
-    hooks: {},
-    metadata: z.object({}),
-  } satisfies Namespace<{}, z.ZodObject<{}>>,
-};
-export type FallbackNamespaces = typeof fallbackNamespaces;

--- a/tests/compat/express-zod-api.ts
+++ b/tests/compat/express-zod-api.ts
@@ -1,6 +1,6 @@
 import { createConfig, createServer } from "express-zod-api";
 import { Server } from "socket.io";
-import { Config, attachSockets } from "zod-sockets";
+import { attachSockets, createSimpleConfig } from "zod-sockets";
 
 const serverConfig = createConfig({
   server: { listen: 8090 },
@@ -10,10 +10,7 @@ const serverConfig = createConfig({
 
 const { httpServer, logger } = await createServer(serverConfig, {});
 
-const socketsConfig = new Config({
-  logger,
-  timeout: 2000,
-});
+const socketsConfig = createSimpleConfig({ logger });
 
 const io = new Server();
 await attachSockets({

--- a/tests/compat/express-zod-api.ts
+++ b/tests/compat/express-zod-api.ts
@@ -1,12 +1,8 @@
-import {
-  createServer,
-  createConfig as createServerConfig,
-} from "express-zod-api";
+import { createConfig, createServer } from "express-zod-api";
 import { Server } from "socket.io";
-import { createConfig as createSocketsConfig } from "zod-sockets";
-import { attachSockets } from "../../src";
+import { Config, attachSockets } from "zod-sockets";
 
-const serverConfig = createServerConfig({
+const serverConfig = createConfig({
   server: { listen: 8090 },
   cors: false,
   logger: { level: "debug", color: true },
@@ -14,16 +10,15 @@ const serverConfig = createServerConfig({
 
 const { httpServer, logger } = await createServer(serverConfig, {});
 
-const socketsConfig = createSocketsConfig({
+const socketsConfig = new Config({
   logger,
   timeout: 2000,
-  emission: {},
 });
 
 const io = new Server();
 await attachSockets({
   target: httpServer,
   config: socketsConfig,
-  actions: {},
+  actions: [],
   io,
 });


### PR DESCRIPTION
- `createSimpleConfig()` for root namespace only config
- `new Config()` without fallbacks for empty config + `.addNamespace()` for opt-in namespaces