### PR TITLE
Using `z.enum()` for `ws` protocol param `transport`

### DIFF
--- a/example/example-documentation.yaml
+++ b/example/example-documentation.yaml
@@ -44,13 +44,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string

--- a/src/__snapshots__/documentation.spec.ts.snap
+++ b/src/__snapshots__/documentation.spec.ts.snap
@@ -35,13 +35,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -156,13 +153,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -306,13 +300,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -423,13 +414,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -541,13 +529,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -673,13 +658,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -895,13 +877,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1009,13 +988,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1159,13 +1135,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1314,13 +1287,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1418,13 +1388,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1558,13 +1525,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1667,13 +1631,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1762,13 +1723,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1862,13 +1820,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -1966,13 +1921,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -2058,13 +2010,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string
@@ -2200,13 +2149,10 @@ channels:
                 - "4"
               description: Mandatory, the version of the protocol
             transport:
-              oneOf:
-                - type: string
-                  enum:
-                    - polling
-                - type: string
-                  enum:
-                    - websocket
+              type: string
+              enum:
+                - polling
+                - websocket
               description: Mandatory, the name of the transport.
             sid:
               type: string

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -71,7 +71,7 @@ export class Documentation extends AsyncApiBuilder {
               .literal("4")
               .describe("Mandatory, the version of the protocol"),
             transport: z
-              .union([z.literal("polling"), z.literal("websocket")])
+              .enum(["polling", "websocket"])
               .describe("Mandatory, the name of the transport."),
             sid: z.string().optional().describe("The session identifier"),
           }),


### PR DESCRIPTION
Should appear better in docs