### PR TITLE
Removing the word "mandatory" as redundant in protocol

### DIFF
--- a/example/example-documentation.yaml
+++ b/example/example-documentation.yaml
@@ -42,13 +42,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier

--- a/src/__snapshots__/documentation.spec.ts.snap
+++ b/src/__snapshots__/documentation.spec.ts.snap
@@ -33,13 +33,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -151,13 +151,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -298,13 +298,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -412,13 +412,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -527,13 +527,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -656,13 +656,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -875,13 +875,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -986,13 +986,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1133,13 +1133,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1285,13 +1285,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1386,13 +1386,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1523,13 +1523,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1629,13 +1629,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1721,13 +1721,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1818,13 +1818,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -1919,13 +1919,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -2008,13 +2008,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier
@@ -2147,13 +2147,13 @@ channels:
               type: string
               enum:
                 - "4"
-              description: Mandatory, the version of the protocol
+              description: The version of the protocol
             transport:
               type: string
               enum:
                 - polling
                 - websocket
-              description: Mandatory, the name of the transport.
+              description: The name of the transport
             sid:
               type: string
               description: The session identifier

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -67,12 +67,10 @@ export class Documentation extends AsyncApiBuilder {
         ...walkSchema({
           direction: "in",
           schema: z.object({
-            EIO: z
-              .literal("4")
-              .describe("Mandatory, the version of the protocol"),
+            EIO: z.literal("4").describe("The version of the protocol"),
             transport: z
               .enum(["polling", "websocket"])
-              .describe("Mandatory, the name of the transport."),
+              .describe("The name of the transport"),
             sid: z.string().optional().describe("The session identifier"),
           }),
           ...commons,


### PR DESCRIPTION
fields already marked as required