### PR TITLE
Detaching from OpenAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "openapi3-ts": "^4.2.2",
     "ramda": "^0.29.1",
     "yaml": "^2.4.1"
   },

--- a/src/__snapshots__/documentation-helpers.spec.ts.snap
+++ b/src/__snapshots__/documentation-helpers.spec.ts.snap
@@ -62,9 +62,7 @@ exports[`Documentation helpers > depictDefault() > should set default property 1
 
 exports[`Documentation helpers > depictDiscriminatedUnion() > should wrap next depicters in oneOf prop and set discriminator prop 1`] = `
 {
-  "discriminator": {
-    "propertyName": "status",
-  },
+  "discriminator": "status",
   "oneOf": [
     {
       "properties": {

--- a/src/__snapshots__/documentation.spec.ts.snap
+++ b/src/__snapshots__/documentation.spec.ts.snap
@@ -176,8 +176,7 @@ channels:
           format: tuple
           properties:
             "0":
-              discriminator:
-                propertyName: type
+              discriminator: type
               oneOf:
                 - type: object
                   properties:
@@ -211,8 +210,7 @@ channels:
           format: tuple
           properties:
             "0":
-              discriminator:
-                propertyName: status
+              discriminator: status
               oneOf:
                 - type: object
                   properties:

--- a/src/async-api/commons.ts
+++ b/src/async-api/commons.ts
@@ -108,7 +108,7 @@ export type SchemaObjectType =
   | "array";
 
 /**
- * @desc extends DRAFT-07
+ * @desc DRAFT-07
  * @link https://json-schema.org/specification-links#draft-7
  * @link https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01
  * */
@@ -130,7 +130,7 @@ interface Draft07 {
   maxProperties?: number;
   minProperties?: number;
   enum?: any[];
-  const: any; // @todo explore: enum of single value
+  const?: any; // @todo explore: enum of single value
   examples?: any[];
   // if,then,else
   readOnly?: boolean;

--- a/src/async-api/commons.ts
+++ b/src/async-api/commons.ts
@@ -1,7 +1,5 @@
 import type {
-  InfoObject as OASInfoObject,
   ServerVariableObject as OASServerVariableObject,
-  ReferenceObject,
   SchemaObject,
 } from "openapi3-ts/oas31";
 import {
@@ -35,8 +33,25 @@ export interface ServerObject {
   bindings?: Bindings<WSServerBinding>;
 }
 
+export interface ContactObject {
+  name?: string;
+  url?: string;
+  email?: string;
+}
+
+export interface LicenseObject {
+  name: string;
+  url?: string;
+}
+
 /** @since 3.0.0 contains tags and externalDocs */
-export interface InfoObject extends OASInfoObject {
+export interface InfoObject {
+  title: string;
+  version: string;
+  description?: string;
+  termsOfService?: string;
+  contact?: ContactObject;
+  license?: LicenseObject;
   tags?: TagObject[];
   externalDocs?: ExternalDocumentationObject;
 }
@@ -58,6 +73,10 @@ export interface AsyncApiObject {
  * @since 3.0.0 An identifier for the described channel. The channelId value is case-sensitive.
  * */
 export type ChannelsObject = Record<string, ChannelObject>;
+
+export interface ReferenceObject {
+  $ref: string;
+}
 
 /** @since 3.0.0 renamed; added address, title, summary, messages, servers, tags, externalDocs; removed pubs/subs */
 export interface ChannelObject {

--- a/src/async-api/commons.ts
+++ b/src/async-api/commons.ts
@@ -1,4 +1,3 @@
-import type { SchemaObject } from "openapi3-ts/oas31";
 import {
   WSChannelBinding,
   WSMessageBinding,
@@ -97,6 +96,91 @@ export interface ServerVariableObject {
   default: string | boolean | number;
   description?: string;
   examples?: string[];
+}
+
+export type SchemaObjectType =
+  | "integer"
+  | "number"
+  | "string"
+  | "boolean"
+  | "object"
+  | "null"
+  | "array";
+
+/**
+ * @desc extends DRAFT-07
+ * @link https://json-schema.org/specification-links#draft-7
+ * @link https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01
+ * */
+interface Draft07 {
+  title?: string;
+  type?: SchemaObjectType | SchemaObjectType[];
+  required?: string[];
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: number;
+  minimum?: number;
+  exclusiveMinimum?: number;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean; // @todo explore
+  maxProperties?: number;
+  minProperties?: number;
+  enum?: any[];
+  const: any; // @todo explore: enum of single value
+  examples?: any[];
+  // if,then,else
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  properties?: { [propertyName: string]: SchemaObject | ReferenceObject };
+  patternProperties?: { [pattern: string]: SchemaObject | ReferenceObject }; // @todo explore
+  additionalProperties?: SchemaObject | ReferenceObject | boolean;
+  additionalItems?: SchemaObject;
+  items?: SchemaObject | ReferenceObject;
+  propertyNames?: SchemaObject | ReferenceObject; // @todo explore
+  contains?: SchemaObject; // @todo explore
+  allOf?: (SchemaObject | ReferenceObject)[];
+  oneOf?: (SchemaObject | ReferenceObject)[];
+  anyOf?: (SchemaObject | ReferenceObject)[];
+  not?: SchemaObject | ReferenceObject;
+  /**
+   * @desc JSON Schema compliant Content-Type, optional when specified as a key of ContentObject
+   * @example image/png
+   */
+  contentMediaType?: string;
+  /**
+   * @desc Specifies the Content-Encoding for the schema, supports all encodings from RFC4648, and "quoted-printable" from RFC2045
+   * @override format
+   * @see https://datatracker.ietf.org/doc/html/rfc4648
+   * @see https://datatracker.ietf.org/doc/html/rfc2045#section-6.7
+   * @example base64
+   */
+  contentEncoding?: string;
+}
+
+/** @link https://www.asyncapi.com/docs/reference/specification/v3.0.0#schemaObject */
+export interface SchemaObject extends Draft07 {
+  // overrides:
+  description?: string; // supports markdown
+  format?:
+    | "int32" // no changes, but declared as more loose
+    | "int64"
+    | "float"
+    | "double"
+    | "byte"
+    | "binary"
+    | "date"
+    | "date-time"
+    | "password"
+    | string;
+  default?: any; // must comply the type
+  // proprietary:
+  discriminator?: string;
+  externalDocs?: ExternalDocumentationObject | ReferenceObject;
+  deprecated?: boolean;
 }
 
 /** @since 3.0.0 added replies */

--- a/src/async-api/commons.ts
+++ b/src/async-api/commons.ts
@@ -1,7 +1,4 @@
-import type {
-  ServerVariableObject as OASServerVariableObject,
-  SchemaObject,
-} from "openapi3-ts/oas31";
+import type { SchemaObject } from "openapi3-ts/oas31";
 import {
   WSChannelBinding,
   WSMessageBinding,
@@ -95,7 +92,10 @@ export interface ChannelObject {
   bindings?: Bindings<WSChannelBinding>;
 }
 
-export interface ServerVariableObject extends OASServerVariableObject {
+export interface ServerVariableObject {
+  enum?: string[] | boolean[] | number[];
+  default: string | boolean | number;
+  description?: string;
   examples?: string[];
 }
 

--- a/src/async-api/helpers.ts
+++ b/src/async-api/helpers.ts
@@ -1,0 +1,7 @@
+import { ReferenceObject, SchemaObject } from "./commons";
+
+export function isReferenceObject(
+  obj: SchemaObject | ReferenceObject,
+): obj is ReferenceObject {
+  return "$ref" in obj;
+}

--- a/src/async-api/ws-binding.ts
+++ b/src/async-api/ws-binding.ts
@@ -1,4 +1,4 @@
-import type { ReferenceObject, SchemaObject } from "openapi3-ts/oas31";
+import type { ReferenceObject, SchemaObject } from "./commons";
 /**
  * @see https://github.com/asyncapi/bindings/tree/master/websockets
  * @desc This object MUST NOT contain any properties. Its name is reserved for future use.

--- a/src/documentation-helpers.ts
+++ b/src/documentation-helpers.ts
@@ -1,11 +1,5 @@
 import assert from "node:assert/strict";
 import {
-  ReferenceObject,
-  SchemaObject,
-  SchemaObjectType,
-  isReferenceObject,
-} from "openapi3-ts/oas31";
-import {
   concat,
   fromPairs,
   map,
@@ -15,7 +9,14 @@ import {
   xprod,
 } from "ramda";
 import { z } from "zod";
-import { MessageObject, OperationObject } from "./async-api/commons";
+import {
+  MessageObject,
+  OperationObject,
+  ReferenceObject,
+  SchemaObject,
+  SchemaObjectType,
+} from "./async-api/commons";
+import { isReferenceObject } from "./async-api/helpers";
 import { hasCoercion, tryToTransform } from "./common-helpers";
 import {
   HandlingRules,
@@ -72,7 +73,7 @@ export const depictDiscriminatedUnion: Depicter<
   z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
 > = ({ schema: { options, discriminator }, next }) => {
   return {
-    discriminator: { propertyName: discriminator },
+    discriminator,
     oneOf: Array.from(options.values()).map(next),
   };
 };

--- a/src/documentation.spec.ts
+++ b/src/documentation.spec.ts
@@ -1,4 +1,4 @@
-import { SchemaObject } from "openapi3-ts/oas31";
+import { SchemaObject } from "./async-api/commons";
 import { config as exampleConfig } from "../example/config";
 import { actions } from "../example/actions";
 import { ActionsFactory } from "./actions-factory";

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -1,7 +1,10 @@
-import { ContactObject, LicenseObject } from "openapi3-ts/oas31";
 import { z } from "zod";
 import { AbstractAction } from "./action";
-import { MessagesObject } from "./async-api/commons";
+import {
+  ContactObject,
+  LicenseObject,
+  MessagesObject,
+} from "./async-api/commons";
 import { AsyncApiBuilder } from "./async-api/document-builder";
 import { WSChannelBinding } from "./async-api/ws-binding";
 import { lcFirst, makeCleanId } from "./common-helpers";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2939,13 +2939,6 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-openapi3-ts@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-4.2.2.tgz#9460b6626c39f6334f876e43c8de08168d306fdb"
-  integrity sha512-+9g4actZKeb3czfi9gVQ4Br2Ju3KwhCAQJBNaKgye5KggqcBLIhFHH+nIkcm0BUX00TrAJl6dH4JWgM4G4JWrw==
-  dependencies:
-    yaml "^2.3.4"
-
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"


### PR DESCRIPTION
Aiming the strict compliance with AsyncAPI SchemaObject.

Adjustments:

- `discriminator` becomes string