### PR TITLE
Replacing Chalk with Ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "hooks": "husky"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
+    "ansis": "^3.0.0",
     "ramda": "^0.29.1",
     "yaml": "^2.4.1"
   },

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -100,9 +100,7 @@ export const attachSockets = async <NS extends Namespaces>({
     });
     await onStartup(nsCtx);
   }
-  (startupLogo ? console.log : () => {})(
-    getStartupLogo((await import("chalk")).default), // chalk v5 is ESM only
-  );
+  (startupLogo ? console.log : () => {})(getStartupLogo());
   rootLogger.info("Listening", target.address());
   return io.attach(target);
 };

--- a/src/startup-logo.ts
+++ b/src/startup-logo.ts
@@ -1,4 +1,4 @@
-import { ChalkInstance } from "chalk";
+import { hex } from "ansis";
 import { T, always, cond, gt } from "ramda";
 
 const georgia11 = `
@@ -12,15 +12,15 @@ M’   AMV                   MM      ,MI    "Y                     MM           
 AMVmmmmMM  `Ybmd9’   `Wbmd"MML.    P"Ybmmd"   `Ybmd9’   YMbmd’ .JMML. YA. `Mbmmd’   `Mbmo M9mmmP’
 `;
 
-export const getStartupLogo = (chalk: ChalkInstance) =>
+export const getStartupLogo = () =>
   georgia11
     .split("\n")
     .map((line, index) => {
       const color = cond([
-        [gt(4), always(chalk.hex("#FCF434"))],
-        [gt(5), always(chalk.hex("#FFF"))],
-        [gt(8), always(chalk.hex("#9C59D1"))],
-        [T, always(chalk.hex("#2C2C2C"))],
+        [gt(4), always(hex("#FCF434"))],
+        [gt(5), always(hex("#FFF"))],
+        [gt(8), always(hex("#9C59D1"))],
+        [T, always(hex("#2C2C2C"))],
       ])(index);
       return color(line);
     })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     env: {
-      FORCE_COLOR: "2",
+      FORCE_COLOR: "1",
     },
     testTimeout: 10000,
     reporters: "verbose",

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,11 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
+ansis@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.0.0.tgz#26092a37e340562a08c0478fbcb51d94a414b904"
+  integrity sha512-+1TIQkDpVmmQ8Z3LDUYtE0/BpMuiYp/H2pJzyqfACOIw3sONhFrXMUDBTlxmecxEysbTHI3QsM9NLe1vN2ZW1g==
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"


### PR DESCRIPTION
A faster replacement for Chalk having CJS support needed for Jest.
Related topic: https://github.com/webdiscus/ansis/issues/18
