### PR TITLE
Feat: Remote client emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Version 0
 
+### v0.16.0
+
+- Added `.emit()` method to the clients returned by `getClients()` method of `all` or `withRoom()`;
+- Improved types for `getData()` in the for the clients returned by `getClients()` method.
+
+```ts
+// sending to someone knowing their id:
+(await all.getClients())
+  .find(({ id }) => id === "someId")
+  ?.emit("event", ...payload);
+```
+
 ### v0.15.1
 
 - Changed runtime dependency: replaced `chalk` with `ansis`.

--- a/README.md
+++ b/README.md
@@ -333,12 +333,16 @@ import { createSimpleConfig } from "zod-sockets";
 const config = createSimpleConfig({
   hooks: {
     onStartup: async ({ all, withRooms }) => {
-      // sending to everyone in a room
+      // sending to everyone in a room:
       withRooms("room1").broadcast("event", ...payload);
       // sending to everyone within several rooms:
       withRooms(["room1", "room2"]).broadcast("event", ...payload);
-      // sending to everyone everywhere
+      // sending to everyone everywhere:
       all.broadcast("event", ...payload);
+      // sending to some particular user by familiar id:
+      (await all.getClients())
+        .find(({ id }) => id === "someId")
+        ?.emit("event", ...payload);
     },
   },
 });

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -166,6 +166,7 @@ describe("Attach", () => {
           getData: expect.any(Function),
           join: expect.any(Function),
           leave: expect.any(Function),
+          emit: expect.any(Function),
         },
         {
           id: "other",
@@ -173,6 +174,7 @@ describe("Attach", () => {
           getData: expect.any(Function),
           join: expect.any(Function),
           leave: expect.any(Function),
+          emit: expect.any(Function),
         },
       ]);
 

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -55,7 +55,12 @@ export const attachSockets = async <NS extends Namespaces>({
       logger: rootLogger,
       withRooms: makeRoomService({ subject: io, metadata, ...emitCfg }),
       all: {
-        getClients: async () => getRemoteClients(await ns.fetchSockets()),
+        getClients: async () =>
+          getRemoteClients({
+            sockets: await ns.fetchSockets(),
+            metadata,
+            ...emitCfg,
+          }),
         getRooms: () => Array.from(ns.adapter.rooms.keys()),
         broadcast: makeEmitter({ subject: io, ...emitCfg }),
       },

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -7,7 +7,7 @@ import { makeDistribution } from "./distribution";
 import { EmitterConfig, makeEmitter, makeRoomService } from "./emission";
 import { ClientContext, IndependentContext } from "./handler";
 import { Namespaces, normalizeNS } from "./namespace";
-import { getRemoteClients } from "./remote-client";
+import { makeRemoteClients } from "./remote-client";
 import { getStartupLogo } from "./startup-logo";
 
 export const attachSockets = async <NS extends Namespaces>({
@@ -56,7 +56,7 @@ export const attachSockets = async <NS extends Namespaces>({
       withRooms: makeRoomService({ subject: io, metadata, ...emitCfg }),
       all: {
         getClients: async () =>
-          getRemoteClients({
+          makeRemoteClients({
             sockets: await ns.fetchSockets(),
             metadata,
             ...emitCfg,

--- a/src/distribution.ts
+++ b/src/distribution.ts
@@ -1,4 +1,5 @@
-import { RemoteSocket, Socket } from "socket.io";
+import type { Socket } from "socket.io";
+import { SomeRemoteSocket } from "./remote-client";
 
 export interface Distribution {
   join: (rooms: string | string[]) => void | Promise<void>;
@@ -6,7 +7,7 @@ export interface Distribution {
 }
 
 export const makeDistribution = (
-  subject: Socket | RemoteSocket<{}, unknown>,
+  subject: Socket | SomeRemoteSocket,
 ): Distribution => ({
   join: subject.join.bind(subject),
   leave: (rooms) =>

--- a/src/emission.spec.ts
+++ b/src/emission.spec.ts
@@ -62,7 +62,7 @@ describe("Emission", () => {
       });
 
       test("should throw on unknown events", async () => {
-        await expect(emitter("invalid")).rejects.toThrowError(
+        await expect(emitter("invalid" as "one", "test")).rejects.toThrowError(
           "Unsupported event invalid",
         );
       });
@@ -99,6 +99,7 @@ describe("Emission", () => {
             getData: expect.any(Function),
             join: expect.any(Function),
             leave: expect.any(Function),
+            emit: expect.any(Function),
           },
           {
             id: "other",
@@ -106,6 +107,7 @@ describe("Emission", () => {
             getData: expect.any(Function),
             join: expect.any(Function),
             leave: expect.any(Function),
+            emit: expect.any(Function),
           },
         ]);
       },

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -65,10 +65,7 @@ export function makeEmitter({
 }: {
   subject:
     | Socket
-    | RemoteSocket<
-        Record<string, z.infer<z.ZodFunction<z.AnyZodTuple, z.ZodVoid>>>,
-        unknown
-      >
+    | RemoteSocket<Record<string, (...args: any[]) => void>, unknown>
     | Socket["broadcast"]
     | Server;
 } & EmitterConfig<EmissionMap>) {

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -66,7 +66,7 @@ export function makeEmitter({
   subject:
     | Socket
     | RemoteSocket<
-        { [K: string]: z.infer<z.ZodFunction<z.AnyZodTuple, z.ZodVoid>> },
+        Record<string, z.infer<z.ZodFunction<z.AnyZodTuple, z.ZodVoid>>>,
         unknown
       >
     | Socket["broadcast"]

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type { RemoteSocket, Server, Socket } from "socket.io";
 import { z } from "zod";
-import { RemoteClient, getRemoteClients } from "./remote-client";
+import { RemoteClient, makeRemoteClients } from "./remote-client";
 
 export interface Emission {
   schema: z.AnyZodTuple;
@@ -101,7 +101,7 @@ export const makeRoomService =
   } & EmitterConfig<E>): RoomService<E, D> =>
   (rooms) => ({
     getClients: async () =>
-      getRemoteClients({
+      makeRemoteClients({
         sockets: await subject.in(rooms).fetchSockets(),
         ...rest,
       }),

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { Server, Socket } from "socket.io";
+import type { RemoteSocket, Server, Socket } from "socket.io";
 import { z } from "zod";
 import { RemoteClient, getRemoteClients } from "./remote-client";
 
@@ -36,7 +36,7 @@ export type RoomService<E extends EmissionMap, D extends z.SomeZodObject> = (
    * @throws Error on ack timeout
    * */
   broadcast: Broadcaster<E>;
-  getClients: () => Promise<RemoteClient<D>[]>;
+  getClients: () => Promise<RemoteClient<E, D>[]>;
 };
 
 export interface EmitterConfig<E extends EmissionMap> {
@@ -46,16 +46,31 @@ export interface EmitterConfig<E extends EmissionMap> {
 
 export function makeEmitter<E extends EmissionMap>(
   props: { subject: Socket } & EmitterConfig<E>,
-): Emitter<EmissionMap>;
+): Emitter<E>;
+export function makeEmitter<E extends EmissionMap>(
+  props: {
+    subject: RemoteSocket<
+      { [K in keyof E]: z.infer<z.ZodFunction<E[K]["schema"], z.ZodVoid>> },
+      unknown
+    >;
+  } & EmitterConfig<E>,
+): Emitter<E>;
 export function makeEmitter<E extends EmissionMap>(
   props: { subject: Socket["broadcast"] | Server } & EmitterConfig<E>,
-): Broadcaster<EmissionMap>;
+): Broadcaster<E>;
 export function makeEmitter({
   subject,
   emission,
   timeout,
 }: {
-  subject: Socket | Socket["broadcast"] | Server;
+  subject:
+    | Socket
+    | RemoteSocket<
+        { [K: string]: z.infer<z.ZodFunction<z.AnyZodTuple, z.ZodVoid>> },
+        unknown
+      >
+    | Socket["broadcast"]
+    | Server;
 } & EmitterConfig<EmissionMap>) {
   /**
    * @throws z.ZodError on validation
@@ -86,7 +101,10 @@ export const makeRoomService =
   } & EmitterConfig<E>): RoomService<E, D> =>
   (rooms) => ({
     getClients: async () =>
-      getRemoteClients(await subject.in(rooms).fetchSockets()),
+      getRemoteClients({
+        sockets: await subject.in(rooms).fetchSockets(),
+        ...rest,
+      }),
     broadcast: makeEmitter({
       ...rest,
       subject: subject.to(rooms),

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import type { RemoteSocket, Server, Socket } from "socket.io";
 import { z } from "zod";
-import { RemoteClient, makeRemoteClients } from "./remote-client";
+import {
+  RemoteClient,
+  SomeRemoteSocket,
+  makeRemoteClients,
+} from "./remote-client";
 
 export interface Emission {
   schema: z.AnyZodTuple;
@@ -63,11 +67,7 @@ export function makeEmitter({
   emission,
   timeout,
 }: {
-  subject:
-    | Socket
-    | RemoteSocket<Record<string, (...args: any[]) => void>, unknown>
-    | Socket["broadcast"]
-    | Server;
+  subject: Socket | SomeRemoteSocket | Socket["broadcast"] | Server;
 } & EmitterConfig<EmissionMap>) {
   /**
    * @throws z.ZodError on validation

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,7 +13,7 @@ export interface IndependentContext<
     /** @desc Returns the list of available rooms */
     getRooms: () => string[];
     /** @desc Returns the list of familiar clients */
-    getClients: () => Promise<RemoteClient<D>[]>;
+    getClients: () => Promise<RemoteClient<E, D>[]>;
     /** @desc Emits an event to everyone */
     broadcast: Broadcaster<E>;
   };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -58,6 +58,7 @@ describe("Entrypoint", () => {
             id: "",
             rooms: [""],
             getData: () => ({ count: 1 }),
+            emit: async () => true,
             join: () => {},
             leave: () => {},
           },

--- a/src/remote-client.spec.ts
+++ b/src/remote-client.spec.ts
@@ -12,15 +12,22 @@ describe("RemoteClient", () => {
         data: { name: "TEST" },
         join: vi.fn(),
         leave: vi.fn(),
+        emit: vi.fn(),
       },
-      { id: "TWO", rooms: new Set(["room2"]), join: vi.fn(), leave: vi.fn() },
+      {
+        id: "TWO",
+        rooms: new Set(["room2"]),
+        join: vi.fn(),
+        leave: vi.fn(),
+        emit: vi.fn(),
+      },
     ];
 
     test("should map RemoteSockets to RemoteClients", () => {
       const clients = getRemoteClients({
         sockets: socketsMock as unknown as RemoteSocket<any, unknown>[],
         metadata: z.object({ name: z.string() }),
-        emission: {},
+        emission: { test: { schema: z.tuple([z.string()]) } },
         timeout: 2000,
       });
       expect(clients).toEqual([
@@ -45,6 +52,10 @@ describe("RemoteClient", () => {
       // getData:
       expect(clients[0].getData()).toEqual({ name: "TEST" });
       expect(clients[1].getData()).toEqual({});
+
+      // emit
+      clients[0].emit("test", "something");
+      expect(socketsMock[0].emit).toHaveBeenLastCalledWith("test", "something");
     });
   });
 });

--- a/src/remote-client.spec.ts
+++ b/src/remote-client.spec.ts
@@ -1,7 +1,6 @@
-import { RemoteSocket } from "socket.io";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { makeRemoteClients } from "./remote-client";
+import { SomeRemoteSocket, makeRemoteClients } from "./remote-client";
 
 describe("RemoteClient", () => {
   describe("makeRemoteClients()", () => {
@@ -25,7 +24,7 @@ describe("RemoteClient", () => {
 
     test("should map RemoteSockets to RemoteClients", () => {
       const clients = makeRemoteClients({
-        sockets: socketsMock as unknown as RemoteSocket<any, unknown>[],
+        sockets: socketsMock as unknown as SomeRemoteSocket[],
         metadata: z.object({ name: z.string() }),
         emission: { test: { schema: z.tuple([z.string()]) } },
         timeout: 2000,

--- a/src/remote-client.spec.ts
+++ b/src/remote-client.spec.ts
@@ -1,5 +1,6 @@
 import { RemoteSocket } from "socket.io";
 import { describe, expect, test, vi } from "vitest";
+import { z } from "zod";
 import { getRemoteClients } from "./remote-client";
 
 describe("RemoteClient", () => {
@@ -16,9 +17,12 @@ describe("RemoteClient", () => {
     ];
 
     test("should map RemoteSockets to RemoteClients", () => {
-      const clients = getRemoteClients(
-        socketsMock as unknown as RemoteSocket<any, any>[],
-      );
+      const clients = getRemoteClients({
+        sockets: socketsMock as unknown as RemoteSocket<any, unknown>[],
+        metadata: z.object({ name: z.string() }),
+        emission: {},
+        timeout: 2000,
+      });
       expect(clients).toEqual([
         {
           id: "ONE",
@@ -26,6 +30,7 @@ describe("RemoteClient", () => {
           getData: expect.any(Function),
           join: expect.any(Function),
           leave: expect.any(Function),
+          emit: expect.any(Function),
         },
         {
           id: "TWO",
@@ -33,6 +38,7 @@ describe("RemoteClient", () => {
           getData: expect.any(Function),
           join: expect.any(Function),
           leave: expect.any(Function),
+          emit: expect.any(Function),
         },
       ]);
 

--- a/src/remote-client.spec.ts
+++ b/src/remote-client.spec.ts
@@ -1,10 +1,10 @@
 import { RemoteSocket } from "socket.io";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { getRemoteClients } from "./remote-client";
+import { makeRemoteClients } from "./remote-client";
 
 describe("RemoteClient", () => {
-  describe("getRemoteClients()", () => {
+  describe("makeRemoteClients()", () => {
     const socketsMock = [
       {
         id: "ONE",
@@ -24,7 +24,7 @@ describe("RemoteClient", () => {
     ];
 
     test("should map RemoteSockets to RemoteClients", () => {
-      const clients = getRemoteClients({
+      const clients = makeRemoteClients({
         sockets: socketsMock as unknown as RemoteSocket<any, unknown>[],
         metadata: z.object({ name: z.string() }),
         emission: { test: { schema: z.tuple([z.string()]) } },

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,4 +1,4 @@
-import { RemoteSocket } from "socket.io";
+import type { RemoteSocket } from "socket.io";
 import { z } from "zod";
 import { Distribution, makeDistribution } from "./distribution";
 import { EmissionMap, Emitter, EmitterConfig, makeEmitter } from "./emission";

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -1,6 +1,5 @@
 import { RemoteSocket } from "socket.io";
 import { z } from "zod";
-
 import { Distribution, makeDistribution } from "./distribution";
 import { EmissionMap, Emitter, EmitterConfig, makeEmitter } from "./emission";
 

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -2,19 +2,30 @@ import { RemoteSocket } from "socket.io";
 import { z } from "zod";
 
 import { Distribution, makeDistribution } from "./distribution";
+import { EmissionMap, Emitter, EmitterConfig, makeEmitter } from "./emission";
 
-export interface RemoteClient<D extends z.SomeZodObject> extends Distribution {
+export interface RemoteClient<E extends EmissionMap, D extends z.SomeZodObject>
+  extends Distribution {
   id: string;
   rooms: string[];
   getData: () => Readonly<Partial<z.infer<D>>>;
+  emit: Emitter<E>;
 }
 
-export const getRemoteClients = <D extends z.SomeZodObject>(
-  sockets: RemoteSocket<{}, z.infer<D>>[],
-) =>
-  sockets.map<RemoteClient<D>>((socket) => ({
+export const getRemoteClients = <
+  E extends EmissionMap,
+  D extends z.SomeZodObject,
+>({
+  sockets,
+  ...rest
+}: {
+  sockets: RemoteSocket<any, unknown>[];
+  metadata: D;
+} & EmitterConfig<E>) =>
+  sockets.map<RemoteClient<E, D>>((socket) => ({
     id: socket.id,
     rooms: Array.from(socket.rooms),
-    getData: () => socket.data || {},
+    getData: () => (socket.data || {}) as Partial<D>,
+    emit: makeEmitter({ subject: socket, ...rest }),
     ...makeDistribution(socket),
   }));

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { Distribution, makeDistribution } from "./distribution";
 import { EmissionMap, Emitter, EmitterConfig, makeEmitter } from "./emission";
 
+export type SomeRemoteSocket = RemoteSocket<
+  Record<string, (...args: any[]) => void>,
+  unknown
+>;
+
 export interface RemoteClient<E extends EmissionMap, D extends z.SomeZodObject>
   extends Distribution {
   id: string;
@@ -18,7 +23,7 @@ export const makeRemoteClients = <
   sockets,
   ...rest
 }: {
-  sockets: RemoteSocket<any, unknown>[];
+  sockets: SomeRemoteSocket[];
   metadata: D;
 } & EmitterConfig<E>) =>
   sockets.map<RemoteClient<E, D>>((socket) => ({

--- a/src/remote-client.ts
+++ b/src/remote-client.ts
@@ -12,7 +12,7 @@ export interface RemoteClient<E extends EmissionMap, D extends z.SomeZodObject>
   emit: Emitter<E>;
 }
 
-export const getRemoteClients = <
+export const makeRemoteClients = <
   E extends EmissionMap,
   D extends z.SomeZodObject,
 >({


### PR DESCRIPTION
- adding `all.getClients() :: emit()` and `withRooms().getClients() :: emit()`
- improving the types of `makeEmitter()`, `RemoteClient` and `getRemoteClients()`