### PR TITLE
Exposing `AbstractLogger` type

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 import { expectNotType, expectType } from "tsd";
 import { z } from "zod";
 import {
+  AbstractLogger,
   ClientContext,
   EmissionMap,
   LoggerOverrides,
@@ -16,6 +17,7 @@ describe("Entrypoint", () => {
   });
 
   test("should expose certain types and interfaces", () => {
+    expectType<AbstractLogger>(console);
     expectType<EmissionMap>({});
     expectType<EmissionMap>({ event: { schema: z.tuple([]) } });
     expectType<EmissionMap>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export { Documentation } from "./documentation";
 
 // issue 952
 export type { EmissionMap } from "./emission";
-export type { LoggerOverrides } from "./logger";
+export type { AbstractLogger, LoggerOverrides } from "./logger";
 export type { ClientContext } from "./handler";
 export type { Namespace } from "./namespace";


### PR DESCRIPTION
Can be useful when keeping a separate declaration