### PR TITLE
Temp: avoid Node 22.5

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.18.0, 18.x, 20.9.0, 20.x, 22.0.0, 22.x]
+        node-version: [18.18.0, 18.x, 20.9.0, 20.x, 22.0.0, 22.4]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - name: Get yarn cache dir


### PR DESCRIPTION
there is an issue in 22.5.0, fixed in 22.5.1, but the setup action is not aware yet