### PR TITLE
Removing redundant `event` argument in `Action::execute()`

### DIFF
--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -86,7 +86,6 @@ describe("Action", () => {
     test("should handle simple action", async () => {
       await simpleAction.execute({
         ...commons,
-        event: "test",
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some"],
       });
@@ -102,7 +101,6 @@ describe("Action", () => {
       const ackMock = vi.fn();
       await ackAction.execute({
         ...commons,
-        event: "test",
         logger: loggerMock as unknown as AbstractLogger,
         params: ["some", ackMock],
       });
@@ -119,7 +117,6 @@ describe("Action", () => {
       await expect(
         simpleAction.execute({
           ...commons,
-          event: "test",
           logger: loggerMock as unknown as AbstractLogger,
           params: [], // too short
         }),
@@ -178,7 +175,6 @@ describe("Action", () => {
       await expect(
         ackAction.execute({
           ...commons,
-          event: "test",
           logger: loggerMock as unknown as AbstractLogger,
           params: ["test", ack],
         }),

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,6 @@ export abstract class AbstractAction {
   public abstract getNamespace(): PropertyKey;
   public abstract execute(
     params: {
-      event: string; // @todo this might be redundant
       params: unknown[];
     } & ClientContext<EmissionMap, z.SomeZodObject>,
   ): Promise<void>;
@@ -112,24 +111,23 @@ export class Action<
   }
 
   public override async execute({
-    event,
     params,
     logger,
     ...rest
-  }: {
-    event: string;
-    params: unknown[];
-  } & ClientContext<EmissionMap, z.SomeZodObject>): Promise<void> {
+  }: { params: unknown[] } & ClientContext<
+    EmissionMap,
+    z.SomeZodObject
+  >): Promise<void> {
     const input = this.#parseInput(params);
     logger.debug(
-      `${event}: parsed input (${this.#outputSchema ? "excl." : "no"} ack)`,
+      `${this.#event}: parsed input (${this.#outputSchema ? "excl." : "no"} ack)`,
       input,
     );
     const ack = this.#parseAckCb(params);
     const output = await this.#handler({ input, logger, ...rest });
     const response = this.#parseOutput(output);
     if (ack && response) {
-      logger.debug(`${event}: parsed output`, response);
+      logger.debug(`${this.#event}: parsed output`, response);
       ack(...response);
     }
   }

--- a/src/attach.spec.ts
+++ b/src/attach.spec.ts
@@ -125,7 +125,6 @@ describe("Attach", () => {
       );
       expect(actionsMock[0].execute).toHaveBeenLastCalledWith({
         withRooms: expect.any(Function),
-        event: "test",
         logger: loggerMock,
         params: [[123, 456]],
         client: {

--- a/src/attach.ts
+++ b/src/attach.ts
@@ -106,7 +106,7 @@ export const attachSockets = async <NS extends Namespaces>({
           const event = action.getEvent();
           socket.on(event, async (...params) => {
             try {
-              return await action.execute({ event, params, ...ctx }); // await required
+              return await action.execute({ params, ...ctx }); // await required
             } catch (error) {
               return onError({
                 ...ctx,


### PR DESCRIPTION
The `Action` is made event-aware.