### PR TITLE
Scope the `all` and `withRooms` parameters of the `onStartup` hook to namespace.

### DIFF
--- a/src/attach.ts
+++ b/src/attach.ts
@@ -59,7 +59,7 @@ export const attachSockets = async <NS extends Namespaces>({
     const emitCfg: EmitterConfig<NSEmissions> = { emission, timeout };
     const nsCtx: IndependentContext<NSEmissions, NSMeta> = {
       logger: rootLogger,
-      withRooms: makeRoomService({ subject: io, metadata, ...emitCfg }),
+      withRooms: makeRoomService({ subject: ns, metadata, ...emitCfg }),
       all: {
         getClients: async () =>
           makeRemoteClients({
@@ -68,7 +68,7 @@ export const attachSockets = async <NS extends Namespaces>({
             ...emitCfg,
           }),
         getRooms: () => Array.from(ns.adapter.rooms.keys()),
-        broadcast: makeEmitter({ subject: io, ...emitCfg }),
+        broadcast: makeEmitter({ subject: ns, ...emitCfg }),
       },
     };
     ns.on("connection", async (socket) => {

--- a/src/emission.ts
+++ b/src/emission.ts
@@ -58,14 +58,16 @@ export function makeEmitter<E extends EmissionMap>(
   } & EmitterConfig<E>,
 ): Emitter<E>;
 export function makeEmitter<E extends EmissionMap>(
-  props: { subject: Socket["broadcast"] | Server } & EmitterConfig<E>,
+  props: {
+    subject: Socket["broadcast"] | Server | Namespace;
+  } & EmitterConfig<E>,
 ): Broadcaster<E>;
 export function makeEmitter({
   subject,
   emission,
   timeout,
 }: {
-  subject: Socket | SomeRemoteSocket | Socket["broadcast"] | Server;
+  subject: Socket | SomeRemoteSocket | Namespace | Socket["broadcast"] | Server;
 } & EmitterConfig<EmissionMap>) {
   /**
    * @throws z.ZodError on validation

--- a/tests/system/issue590.spec.ts
+++ b/tests/system/issue590.spec.ts
@@ -138,7 +138,7 @@ describe("Issue #590", () => {
         timeout: 1000,
       });
 
-      // withRooms().broadcast() should reach client:
+      // all.broadcast() should reach client:
       expect(receivedBroadcast).toBe("from onStartup hook");
 
       clientSocket.disconnect();

--- a/tests/system/issue590.spec.ts
+++ b/tests/system/issue590.spec.ts
@@ -1,9 +1,9 @@
 import http from "node:http";
-import {Server} from "socket.io";
-import {io as ioClient} from "socket.io-client";
-import {z} from "zod";
-import {ActionsFactory, attachSockets, Config} from "../../src";
-import {promisify} from "node:util";
+import { Server } from "socket.io";
+import { io as ioClient } from "socket.io-client";
+import { z } from "zod";
+import { ActionsFactory, attachSockets, Config } from "../../src";
+import { promisify } from "node:util";
 import assert from "node:assert/strict";
 
 const port = 8999;
@@ -26,10 +26,10 @@ describe("Issue #590", () => {
       const config = new Config().addNamespace({
         path: "/chat",
         emission: {
-          testBroadcast: {schema: z.tuple([z.string()])},
+          testBroadcast: { schema: z.tuple([z.string()]) },
         },
         hooks: {
-          onConnection: async ({client}) => await client.join("testRoom"),
+          onConnection: async ({ client }) => await client.join("testRoom"),
         },
         metadata: z.object({}),
       });
@@ -40,7 +40,7 @@ describe("Issue #590", () => {
         ns: "/chat",
         event: "testQuery",
         input: z.tuple([]),
-        async handler({withRooms}) {
+        async handler({ withRooms }) {
           const clients = await withRooms("testRoom").getClients();
           clientsInRoom = clients.length;
           await withRooms("testRoom").broadcast("testBroadcast", "hello");

--- a/tests/system/issue590.spec.ts
+++ b/tests/system/issue590.spec.ts
@@ -17,6 +17,11 @@ const port = 8999;
  */
 describe("Issue #590", () => {
   describe("attachSockets() with real Socket.IO", () => {
+    let intervalRef: NodeJS.Timeout | undefined;
+    afterEach(() => {
+      if (intervalRef) clearInterval(intervalRef);
+    });
+
     test("should query and broadcast to rooms joined in onConnection", async () => {
       const httpServer = http.createServer();
       const io = new Server();
@@ -89,7 +94,6 @@ describe("Issue #590", () => {
     test("should broadcast to all from startup hook using all.broadcast", async () => {
       const httpServer = http.createServer();
       const io = new Server();
-      let intervalRef: NodeJS.Timeout | undefined;
 
       const config = new Config().addNamespace({
         path: "/chat",
@@ -139,14 +143,12 @@ describe("Issue #590", () => {
 
       clientSocket.disconnect();
       await promisify(io.close.bind(io))();
-      clearInterval(intervalRef);
       if (httpServer.listening)
         await promisify(httpServer.close.bind(httpServer))();
     });
     test("should broadcast to rooms from startup hook using withRooms", async () => {
       const httpServer = http.createServer();
       const io = new Server();
-      let intervalRef: NodeJS.Timeout | undefined;
 
       const config = new Config().addNamespace({
         path: "/chat",
@@ -199,7 +201,6 @@ describe("Issue #590", () => {
 
       clientSocket.disconnect();
       await promisify(io.close.bind(io))();
-      clearInterval(intervalRef);
       if (httpServer.listening)
         await promisify(httpServer.close.bind(httpServer))();
     });

--- a/tests/system/issue590.spec.ts
+++ b/tests/system/issue590.spec.ts
@@ -89,7 +89,7 @@ describe("Issue #590", () => {
     test("should broadcast to all from startup hook using all.broadcast", async () => {
       const httpServer = http.createServer();
       const io = new Server();
-      let intervalRef;
+      let intervalRef: NodeJS.Timeout | undefined;
 
       const config = new Config().addNamespace({
         path: "/chat",
@@ -146,7 +146,7 @@ describe("Issue #590", () => {
     test("should broadcast to rooms from startup hook using withRooms", async () => {
       const httpServer = http.createServer();
       const io = new Server();
-      let intervalRef;
+      let intervalRef: NodeJS.Timeout | undefined;
 
       const config = new Config().addNamespace({
         path: "/chat",


### PR DESCRIPTION
Hello, apologies for this almost duplicate PR of https://github.com/RobinTail/zod-sockets/pull/590.

### Problem
The `all` or `withRooms` emitter/broadcasters parameters of the `onStartup` do not broadcast to any clients joined under a specific namespace.

### Solution
Scope the `all` and `withRooms` parameters of the `onStartup` hook to namespace.

Updated the system tests under issue#590 to include these cases as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadcasts, room services, and emitter behavior now operate at the namespace level so startup-hook and emitter broadcasts target a specific namespace rather than the global server; namespace-scoped actions align with the intended audience.

* **Tests**
  * Added system tests verifying startup-hook broadcasts to all clients in a namespace and to clients in specific rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->